### PR TITLE
Add ranged streams

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,12 +17,12 @@ before_script:
 script:
 - |
   cargo build &&
-  cargo test &&
-  travis-cargo --only nightly bench &&
+  cargo test --features range_stream &&
+  travis-cargo --only nightly bench -- --features range_stream &&
   travis-cargo --only stable doc
 after_success:
 - travis-cargo --only stable doc-upload
-- travis-cargo coveralls --no-sudo
+- travis-cargo coveralls --no-sudo -- --features range_stream
 env:
   global:
   - TRAVIS_CARGO_NIGHTLY_FEATURE=""

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,8 @@ license = "MIT"
 
 name = "combine"
 path = "src/lib.rs"
+
+[features]
+# Using a feature in combine is considered to be unstable (does not adhere to semver) if you use one or more features
+# then you have been warned that you may experience breaking changes between any release
+range_stream = []

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 (Previously named parser-combinators)
 
-An implementation of parser combinators for Rust, inspired by the Haskell library [Parsec](https://hackage.haskell.org/package/parsec). As in Parsec the parsers are [LL(1)](https://en.wikipedia.org/wiki/LL_parser) by default but they can opt-in to arbitrary lookahed using the [try  combinator](https://marwes.github.io/combine/combine/fn.try.html).
+An implementation of parser combinators for Rust, inspired by the Haskell library [Parsec](https://hackage.haskell.org/package/parsec). As in Parsec the parsers are [LL(1)](https://en.wikipedia.org/wiki/LL_parser) by default but they can opt-in to arbitrary lookahead using the [try  combinator](https://marwes.github.io/combine/combine/fn.try.html).
 
 ##Example
 
@@ -33,7 +33,13 @@ A parser combinator is, broadly speaking, a function which takes several parsers
 
 The library adheres to [semantic versioning](http://semver.org).
 
-If you end up trying it I welcome any feedback from your experience with it. I am usually reachable within a dat by opening an issue or sending an email. I am also testing gitter for smaller questions.
+If you end up trying it I welcome any feedback from your experience with it. I am usually reachable within a day by opening an issue or sending an email. I am also testing gitter for smaller questions.
+
+## Experimental additions
+
+Though `combine` is stable now that does not mean it is done. To make it as easy as possible to opt-in to these upcoming changes cargo features is used. If you include one or more of these features in your project you may experience breaking changes between versions. As these changes are unstable I really appreciate any and all feedback on these to help make the additions the best they can be.
+
+* __range_stream__ Adds parsers for zero copy parsing through the use of the `RangeStream` trait.
 
 ## Extra
 
@@ -43,7 +49,7 @@ You can find older versions of combine (parser-combinators) [here](https://crate
 
 ## Contributing
 
-The easiest way to contribute is to just open an issue about any problems you encounter using combine but if you are intersted in adding something to the library here is a list of some of the easier things to work on to get started.
+The easiest way to contribute is to just open an issue about any problems you encounter using combine but if you are interested in adding something to the library here is a list of some of the easier things to work on to get started.
 
 * __Add additional parsers__ There is a list of parsers which aren't implemented [here][add parsers] but if you have a suggestion for another parser just leave a suggestion on the issue itself.
 * __Add additional examples__ More examples for using combine will always be useful!
@@ -59,7 +65,7 @@ Here is a list containing most of the breaking changes in older versions of comb
 * `&[T]` streams has had the `Item` type changed from `&T` to `T` and requires a `T: Copy` bound.
 
 ### 1.0.0-beta.3
-* `Error::Unexpected` holds an `Info<T, R>` instead of just a T to make it consitent with the other variants.
+* `Error::Unexpected` holds an `Info<T, R>` instead of just a T to make it consistent with the other variants.
 
 ### 1.0.0-beta.2
 * `Info<T>` and `Error<T>` has had their signatures changed to `Info<T, R>` and `Error<T, R>`. `Info` has a new variant which is specified by `R` and defines the type for range errors. `ParseError<T: Positioner>` has been changed to `ParseError<S: Stream>` (S is the stream type of the parser).

--- a/src/combinator.rs
+++ b/src/combinator.rs
@@ -1601,4 +1601,11 @@ mod tests {
         let result = take_while(|c: char| c.is_digit(10)).parse("123abc");
         assert_eq!(result, Ok(("123", "abc")));
     }
+
+    #[test]
+    fn range_string_no_char_boundary_error() {
+        let mut parser = range("hello");
+        let result = parser.parse("hell\u{00EE} world");
+        assert!(result.is_err());
+    }
 }

--- a/src/combinator.rs
+++ b/src/combinator.rs
@@ -1,6 +1,8 @@
 use std::iter::FromIterator;
 use std::marker::PhantomData;
-use primitives::{Info, Parser, ParseResult, ParseError, Positioner, Stream, RangeStream, State, Error, Consumed};
+use primitives::{Info, Parser, ParseResult, ParseError, Positioner, Stream, State, Error, Consumed};
+#[cfg(feature = "range_stream")]
+use primitives::RangeStream;
 
 macro_rules! impl_parser {
     ($name: ident ($first: ident, $($ty_var: ident),*), $inner_type: ty) => {
@@ -1391,8 +1393,10 @@ tuple_parser!(A, B, C, D, E, F, G, H, I, J, K);
 tuple_parser!(A, B, C, D, E, F, G, H, I, J, K, L);
 
 
+#[cfg(feature = "range_stream")]
 pub struct Range<I>(I)
     where I: RangeStream + PartialEq;
+#[cfg(feature = "range_stream")]
 impl <I, E> Parser for Range<I>
     where I: RangeStream<Item=E, Range=I> + PartialEq + Positioner<Position=E::Position>
         , E: Positioner + Clone {
@@ -1433,13 +1437,16 @@ impl <I, E> Parser for Range<I>
 /// assert!(result.is_err());
 /// # }
 /// ```
+#[cfg(feature = "range_stream")]
 pub fn range<I, E>(i: I) -> Range<I>
     where I: RangeStream<Item=E, Range=I> + PartialEq + Positioner<Position=E::Position>
         , E: Positioner + Clone {
     Range(i)
 }
 
+#[cfg(feature = "range_stream")]
 pub struct Take<I>(usize, PhantomData<fn (I) -> I>);
+#[cfg(feature = "range_stream")]
 impl <I, E> Parser for Take<I>
     where I: RangeStream<Item=E>
         , E: Positioner<Position=I::Position> + Clone {
@@ -1464,12 +1471,15 @@ impl <I, E> Parser for Take<I>
 /// assert!(result.is_err());
 /// # }
 /// ```
+#[cfg(feature = "range_stream")]
 pub fn take<I>(n: usize) -> Take<I>
     where I: RangeStream {
     Take(n, PhantomData)
 }
 
+#[cfg(feature = "range_stream")]
 pub struct TakeWhile<I, F>(F, PhantomData<fn (I) -> I>);
+#[cfg(feature = "range_stream")]
 impl <I, E, F> Parser for TakeWhile<I, F>
     where I: RangeStream<Item=E>
         , E: Positioner<Position=I::Position> + Clone
@@ -1495,13 +1505,16 @@ impl <I, E, F> Parser for TakeWhile<I, F>
 /// assert_eq!(result, Ok(("", "abc")));
 /// # }
 /// ```
+#[cfg(feature = "range_stream")]
 pub fn take_while<I, F>(f: F) -> TakeWhile<I, F>
     where I: RangeStream
         , F: FnMut(I::Item) -> bool {
     TakeWhile(f, PhantomData)
 }
 
+#[cfg(feature = "range_stream")]
 pub struct TakeWhile1<I, F>(F, PhantomData<fn (I) -> I>);
+#[cfg(feature = "range_stream")]
 impl <I, F> Parser for TakeWhile1<I, F>
     where I: RangeStream
         , F: FnMut(I::Item) -> bool {
@@ -1539,6 +1552,7 @@ impl <I, F> Parser for TakeWhile1<I, F>
 /// assert!(result.is_err());
 /// # }
 /// ```
+#[cfg(feature = "range_stream")]
 pub fn take_while1<I, F>(f: F) -> TakeWhile1<I, F>
     where I: RangeStream
         , F: FnMut(I::Item) -> bool {
@@ -1584,6 +1598,7 @@ mod tests {
                          Error::Expected("my expected digit".into())]
         }));
     }
+
     #[test]
     fn tuple_parse_error() {
         let mut parser = (digit(), digit());
@@ -1596,12 +1611,14 @@ mod tests {
         }));
     }
 
+    #[cfg(feature = "range_stream")]
     #[test]
     fn take_while_test() {
         let result = take_while(|c: char| c.is_digit(10)).parse("123abc");
         assert_eq!(result, Ok(("123", "abc")));
     }
 
+    #[cfg(feature = "range_stream")]
     #[test]
     fn range_string_no_char_boundary_error() {
         let mut parser = range("hello");

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -513,8 +513,20 @@ impl <'a> RangeStream for &'a str {
         Ok((&self[..len], &self[len..]))
     }
     fn uncons_range(self, size: usize) -> Result<(&'a str, &'a str), Error<char, &'a str>> {
+        fn is_char_boundary(s: &str, index: usize) -> bool {
+            if index == s.len() { return true; }
+            match s.as_bytes().get(index) {
+                None => false,
+                Some(&b) => b < 128 || b >= 192,
+            }
+        }
         if size < self.len() {
-            Ok((&self[0..size], &self[size..]))
+            if is_char_boundary(self, size) {
+                Ok((&self[0..size], &self[size..]))
+            }
+            else {
+                Err(Error::Message("uncons_range on non character boundary".into()))
+            }
         }
         else {
             Err(Error::end_of_input())

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -419,6 +419,7 @@ impl <I: Stream> State<I> {
     }
 }
 
+#[cfg(feature = "range_stream")]
 impl <I, E> State<I>
     where I: RangeStream<Item=E> + Positioner<Position=E::Position>
         , E: Positioner + Clone {
@@ -445,6 +446,7 @@ impl <I, E> State<I>
     }
 }
 
+#[cfg(feature = "range_stream")]
 impl <I: RangeStream> State<I> {
 
     ///Removes items from the input while `predicate` returns `true`.
@@ -490,6 +492,7 @@ pub trait Stream : Clone {
     fn uncons(self) -> Result<(Self::Item, Self), Error<Self::Item, Self::Range>>;
 }
 
+#[cfg(feature = "range_stream")]
 pub trait RangeStream: Stream + Positioner {
     ///Takes `size` elements from the stream
     ///Fails if the length of the stream is less than `size`.
@@ -504,6 +507,7 @@ pub trait RangeStream: Stream + Positioner {
     fn len(&self) -> usize;
 }
 
+#[cfg(feature = "range_stream")]
 impl <'a> RangeStream for &'a str {
     fn uncons_while<F>(self, mut f: F) -> Result<(&'a str, &'a str), Error<char, &'a str>>
         where F: FnMut(Self::Item) -> bool {
@@ -537,6 +541,7 @@ impl <'a> RangeStream for &'a str {
     }
 }
 
+#[cfg(feature = "range_stream")]
 impl <'a, T> RangeStream for &'a [T]
 where T: Positioner + Copy {
     fn uncons_range(self, size: usize) -> Result<(&'a [T], &'a [T]), Error<T, &'a [T]>> {


### PR DESCRIPTION
Ranged streams are streams which in addition to allowing taking elements one by one also are able to take an entire range of elements efficiently. For example the stream `&str`  can be split into two different slices. This should give a large performance boost to streams which uses it as they can avoid allocating every time multiple tokens are needed and instead just use the data in the stream itself.

This PR is a breaking change since it changes the `ParseError<T = Stream::Item>` to `ParseError<S: Stream>` so it needs to be merged before 1.0 (I had hoped not to break anything after 1.0- beta but this is only minor breaking change and only if you used some types directly from the primitives module). I might lift that breaking change out and merge it separately, allowing 1.0 to be released and RangeStream to be tested a bit more.