### PR TITLE
Adds support for range errors in preparation for RangeStream

### DIFF
--- a/benches/json.rs
+++ b/benches/json.rs
@@ -7,9 +7,9 @@ use std::io::Read;
 use std::fs::File;
 use std::path::Path;
 
-use pc::primitives::{from_iter, Consumed, Parser, ParseError, State, Stream};
+use pc::primitives::{from_iter, Consumed, Parser, ParseError, ParseResult, State, Stream};
 use pc::combinator::{any, between, many, many1, optional, parser, satisfy, sep_by, Expected, FnParser, Skip, ParserExt};
-use pc::char::{char, digit, spaces, Spaces, string, ParseResult};
+use pc::char::{char, digit, spaces, Spaces, string};
 
 #[derive(PartialEq, Debug)]
 enum Value {

--- a/src/char.rs
+++ b/src/char.rs
@@ -1,8 +1,6 @@
-use primitives::{Consumed, Parser, ParseError, Error, State, Stream};
+use primitives::{Consumed, Parser, ParseError, ParseResult, Error, State, Stream};
 use combinator::{Expected, satisfy, Satisfy, skip_many, SkipMany, token, Token, ParserExt, With};
 use std::marker::PhantomData;
-
-pub type ParseResult<O, I> = ::primitives::ParseResult<O, I, char>;
 
 macro_rules! impl_char_parser {
     ($name: ident ($($ty_var: ident),*), $inner_type: ty) => {
@@ -16,7 +14,7 @@ macro_rules! impl_char_parser {
         fn parse_lazy(&mut self, input: State<<Self as Parser>::Input>) -> ParseResult<<Self as Parser>::Output, <Self as Parser>::Input> {
             self.0.parse_lazy(input)
         }
-        fn add_error(&mut self, errors: &mut ParseError<<Self::Input as Stream>::Item>) {
+        fn add_error(&mut self, errors: &mut ParseError<Self::Input>) {
             self.0.add_error(errors)
         }
     }
@@ -172,7 +170,7 @@ impl <I> Parser for String<I>
         }
         Ok((self.0, if consumed { Consumed::Consumed(input) } else { Consumed::Empty(input) }))
     }
-    fn add_error(&mut self, errors: &mut ParseError<<Self::Input as Stream>::Item>) {
+    fn add_error(&mut self, errors: &mut ParseError<Self::Input>) {
         errors.add_error(Error::Expected(self.0.into()));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@
 //!     let mut integer_list = sep_by(integer, spaces.skip(char(',')));
 //! 
 //!     //Call parse with the input to execute the parser
-//!     let result: Result<(Vec<i32>, &str), ParseError<char>> = integer_list.parse(input);
+//!     let result: Result<(Vec<i32>, &str), ParseError<&str>> = integer_list.parse(input);
 //!     match result {
 //!         Ok((value, _remaining_input)) => println!("{:?}", value),
 //!         Err(err) => println!("{}", err)
@@ -56,9 +56,8 @@
 //!
 //!```
 //! extern crate combine;
-//! use combine::{between, char, letter, spaces, many1, parser, sep_by, Parser, ParserExt,
-//! ParseResult};
-//! use combine::primitives::{State, Stream};
+//! use combine::{between, char, letter, spaces, many1, parser, sep_by, Parser, ParserExt};
+//! use combine::primitives::{State, Stream, ParseResult};
 //!
 //! #[derive(Debug, PartialEq)]
 //! enum Expr {
@@ -99,7 +98,7 @@
 //!```
 
 #[doc(inline)]
-pub use primitives::{Parser, ParseError, State, from_iter};
+pub use primitives::{Parser, ParseError, ParseResult, State, from_iter};
 #[doc(inline)]
 pub use char::{
     char,
@@ -116,8 +115,6 @@ pub use char::{
     hex_digit,
     oct_digit,
     string,
-
-    ParseResult//use char::ParseResult for compatibility
 };
 #[doc(inline)]
 pub use combinator::{
@@ -432,7 +429,7 @@ r"
         impl StdError for Error {
             fn description(&self) -> &str { "error" }
         }
-        let result: Result<((), _), _> = string("abc")
+        let result: Result<((), _), ParseError<&str>> = string("abc")
             .and_then(|_| Err(Error))
             .parse("abc");
         assert!(result.is_err());


### PR DESCRIPTION
This is a breaking change as it changes the type signature for errors.
Info and Error has an extra parameter where they can specify a range error. ParseError now takes the stream type instead of token type as its parameter. The idea is that ParseError will later be made into type alias when type aliases allow bounds on their parameters. That change should be possible to make without a breaking change once its supported.

```
type ParseError<S: Stream> = ParseError2<S::Item, S::Range>;
```