### PR TITLE
Make T: Copy for &[T] streams

### DIFF
--- a/src/combinator.rs
+++ b/src/combinator.rs
@@ -46,7 +46,7 @@ impl <I> Parser for Any<I>
 /// assert_eq!(char_parser.parse("!").map(|x| x.0), Ok('!'));
 /// assert!(char_parser.parse("").is_err());
 /// let mut byte_parser = any();
-/// assert_eq!(byte_parser.parse(&b"!"[..]).map(|x| x.0), Ok(&b'!'));
+/// assert_eq!(byte_parser.parse(&b"!"[..]).map(|x| x.0), Ok(b'!'));
 /// assert!(byte_parser.parse(&b""[..]).is_err());
 /// # }
 /// ```


### PR DESCRIPTION
As was pointed out to me by @m4rw3r `&[T]` streams are usually on `&[u8]` or other types `T` which are copyable. This would allow the Item type of such streams to be `T` rather than `&T` but has the downside that you can use `&[T]` where `T != Copy`. A newtype could be added which wraps such `&[T]` slices allowing for `&T` items again.

Alternatives:
* Introduce a newtype which can be used to wrap slices with T: Copy instead.
```rust
#[derive(Debug, PartialEq, Clone)]
struct CopySlice<'a, T: 'a>(&'a [T]);

impl <'a, T: Positioner + Copy + 'a> Stream for CopySlice<'a, T> {
    type Item = T;
    type Range = &'a [T];
    fn uncons(self) -> Result<(T, CopySlice<'a, T>), Error<T, CopySlice<'a, T>> {
        ...
    }
}
```

I don't have much of any opinion either way but it needs to be decided before 1.0. Wrapping the slice in a newtype is only necessary for the first call to parse so its only a minor ergonomic win for the case which does not need wrapping, it's more of deciding which way is the least surprising for the majority of users.