### PR TITLE
Add EnvParser (env_parser)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,6 +150,7 @@ pub use combinator::{
     chainl1,
     chainr1,
     choice,
+    env_parser,
     many,
     many1,
     optional,


### PR DESCRIPTION
The function `env_parser` works in the same way as the `parser` function but allows the construction of parsers from `fn (Env, State<I>) -> ParseResult<O, I>`. An implementation of this has been in both `combine-language` and `embed_lang` where it has been very useful by allowing parsers to share some common environment while still allowing each parser to be self contained to a single function.