### PR TITLE
feat: Change the Input on Parser to an argument instead of an associa…

### DIFF
--- a/src/char.rs
+++ b/src/char.rs
@@ -6,16 +6,15 @@ macro_rules! impl_char_parser {
     ($name: ident ($($ty_var: ident),*), $inner_type: ty) => {
     #[derive(Clone)]
     pub struct $name<I $(,$ty_var)*>($inner_type, PhantomData<fn (I) -> I>)
-        where I: Stream<Item=char> $(, $ty_var : Parser<Input=I>)*;
-    impl <I $(,$ty_var)*> Parser for $name<I $(,$ty_var)*>
-        where I: Stream<Item=char> $(, $ty_var : Parser<Input=I>)* {
-        type Input = I;
-        type Output = <$inner_type as Parser>::Output;
+        where I: Stream<Item=char> $(, $ty_var : Parser<I>)*;
+    impl <I $(,$ty_var)*> Parser<I> for $name<I $(,$ty_var)*>
+        where I: Stream<Item=char> $(, $ty_var : Parser<I>)* {
+        type Output = <$inner_type as Parser<I>>::Output;
         fn parse_lazy(&mut self,
-                      input: State<Self::Input>) -> ParseResult<Self::Output, Self::Input> {
+                      input: State<I>) -> ParseResult<Self::Output, I> {
             self.0.parse_lazy(input)
         }
-        fn add_error(&mut self, errors: &mut ParseError<Self::Input>) {
+        fn add_error(&mut self, errors: &mut ParseError<I>) {
             self.0.add_error(errors)
         }
     }
@@ -40,7 +39,7 @@ pub fn char<I>(c: char) -> Token<I>
     token(c)
 }
 
-impl_char_parser! { Digit(), Expected<Satisfy<I, fn (char) -> bool>> }
+impl_char_parser! { Digit(), Expected<I, Satisfy<I, fn (char) -> bool>> }
 ///Parses a digit from a stream containing characters
 pub fn digit<I>() -> Digit<I>
     where I: Stream<Item = char>
@@ -49,7 +48,7 @@ pub fn digit<I>() -> Digit<I>
           PhantomData)
 }
 
-impl_char_parser! { Space(), Expected<Satisfy<I, fn (char) -> bool>> }
+impl_char_parser! { Space(), Expected<I, Satisfy<I, fn (char) -> bool>> }
 ///Parses whitespace
 pub fn space<I>() -> Space<I>
     where I: Stream<Item = char>
@@ -57,7 +56,7 @@ pub fn space<I>() -> Space<I>
     let f: fn(char) -> bool = char::is_whitespace;
     Space(satisfy(f).expected("whitespace"), PhantomData)
 }
-impl_char_parser! { Spaces(), Expected<SkipMany<Space<I>>> }
+impl_char_parser! { Spaces(), Expected<I, SkipMany<Space<I>>> }
 ///Skips over zero or more spaces
 pub fn spaces<I>() -> Spaces<I>
     where I: Stream<Item = char>
@@ -65,7 +64,7 @@ pub fn spaces<I>() -> Spaces<I>
     Spaces(skip_many(space()).expected("whitespaces"), PhantomData)
 }
 
-impl_char_parser! { NewLine(), Expected<Satisfy<I, fn (char) -> bool>> }
+impl_char_parser! { NewLine(), Expected<I, Satisfy<I, fn (char) -> bool>> }
 ///Parses a newline character
 pub fn newline<I>() -> NewLine<I>
     where I: Stream<Item = char>
@@ -74,7 +73,7 @@ pub fn newline<I>() -> NewLine<I>
             PhantomData)
 }
 
-impl_char_parser! { CrLf(), Expected<With<Satisfy<I, fn (char) -> bool>, NewLine<I>>> }
+impl_char_parser! { CrLf(), Expected<I, With<Satisfy<I, fn (char) -> bool>, NewLine<I>>> }
 ///Parses carriage return and newline, returning the newline character.
 pub fn crlf<I>() -> CrLf<I>
     where I: Stream<Item = char>
@@ -85,7 +84,7 @@ pub fn crlf<I>() -> CrLf<I>
          PhantomData)
 }
 
-impl_char_parser! { Tab(), Expected<Satisfy<I, fn (char) -> bool>> }
+impl_char_parser! { Tab(), Expected<I, Satisfy<I, fn (char) -> bool>> }
 ///Parses a tab character
 pub fn tab<I>() -> Tab<I>
     where I: Stream<Item = char>
@@ -94,7 +93,7 @@ pub fn tab<I>() -> Tab<I>
         PhantomData)
 }
 
-impl_char_parser! { Upper(), Expected<Satisfy<I, fn (char) -> bool>> }
+impl_char_parser! { Upper(), Expected<I, Satisfy<I, fn (char) -> bool>> }
 ///Parses an uppercase letter
 pub fn upper<I>() -> Upper<I>
     where I: Stream<Item = char>
@@ -103,7 +102,7 @@ pub fn upper<I>() -> Upper<I>
           PhantomData)
 }
 
-impl_char_parser! { Lower(), Expected<Satisfy<I, fn (char) -> bool>> }
+impl_char_parser! { Lower(), Expected<I, Satisfy<I, fn (char) -> bool>> }
 ///Parses an lowercase letter
 pub fn lower<I>() -> Lower<I>
     where I: Stream<Item = char>
@@ -113,7 +112,7 @@ pub fn lower<I>() -> Lower<I>
           PhantomData)
 }
 
-impl_char_parser! { AlphaNum(), Expected<Satisfy<I, fn (char) -> bool>> }
+impl_char_parser! { AlphaNum(), Expected<I, Satisfy<I, fn (char) -> bool>> }
 ///Parses either an alphabet letter or digit
 pub fn alpha_num<I>() -> AlphaNum<I>
     where I: Stream<Item = char>
@@ -123,7 +122,7 @@ pub fn alpha_num<I>() -> AlphaNum<I>
              PhantomData)
 }
 
-impl_char_parser! { Letter(), Expected<Satisfy<I, fn (char) -> bool>> }
+impl_char_parser! { Letter(), Expected<I, Satisfy<I, fn (char) -> bool>> }
 ///Parses an alphabet letter
 pub fn letter<I>() -> Letter<I>
     where I: Stream<Item = char>
@@ -132,7 +131,7 @@ pub fn letter<I>() -> Letter<I>
            PhantomData)
 }
 
-impl_char_parser! { OctDigit(), Expected<Satisfy<I, fn (char) -> bool>> }
+impl_char_parser! { OctDigit(), Expected<I, Satisfy<I, fn (char) -> bool>> }
 ///Parses an octal digit
 pub fn oct_digit<I>() -> OctDigit<I>
     where I: Stream<Item = char>
@@ -141,7 +140,7 @@ pub fn oct_digit<I>() -> OctDigit<I>
              PhantomData)
 }
 
-impl_char_parser! { HexDigit(), Expected<Satisfy<I, fn (char) -> bool>> }
+impl_char_parser! { HexDigit(), Expected<I, Satisfy<I, fn (char) -> bool>> }
 ///Parses a hexdecimal digit with uppercase and lowercase
 pub fn hex_digit<I>() -> HexDigit<I>
     where I: Stream<Item = char>
@@ -153,10 +152,9 @@ pub fn hex_digit<I>() -> HexDigit<I>
 
 
 #[derive(Clone)]
-pub struct String<I>(&'static str, PhantomData<I>);
-impl<I> Parser for String<I> where I: Stream<Item = char>
+pub struct String<I>(&'static str, PhantomData<fn(I) -> I>);
+impl<I> Parser<I> for String<I> where I: Stream<Item = char>
 {
-    type Input = I;
     type Output = &'static str;
     fn parse_lazy(&mut self, mut input: State<I>) -> ParseResult<&'static str, I> {
         let start = input.position;
@@ -196,7 +194,7 @@ impl<I> Parser for String<I> where I: Stream<Item = char>
             Consumed::Empty(input)
         }))
     }
-    fn add_error(&mut self, errors: &mut ParseError<Self::Input>) {
+    fn add_error(&mut self, errors: &mut ParseError<I>) {
         errors.add_error(Error::Expected(self.0.into()));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,7 +166,7 @@ mod tests {
     fn integer<'a, I>(input: State<I>) -> ParseResult<i64, I>
         where I: Stream<Item = char>
     {
-        let (s, input) = try!(many1::<String, _>(digit())
+        let (s, input) = try!(many1::<String, _, _>(digit())
                                   .expected("integer")
                                   .parse_state(input));
         let mut n = 0;
@@ -298,7 +298,7 @@ Expected 'integer', 'identifier', '[' or '('
         fn plus(l: Expr, r: Expr) -> Expr {
             Expr::Plus(Box::new(l), Box::new(r))
         }
-        let mul = char('*').map(|_| times);
+        let mul = char('*').map::<_, fn(Expr, Expr) -> Expr>(|_: char| times);
         let add = char('+').map(|_| plus);
         let factor = chainl1(parser(expr), mul);
         chainl1(factor, add).parse_state(input)
@@ -363,7 +363,7 @@ Expected 'integer', 'identifier', '[' or '('
 
     #[test]
     fn sep_by_error_consume() {
-        let mut p = sep_by::<Vec<_>, _, _>(string("abc"), char(','));
+        let mut p = sep_by::<Vec<_>, _, _, _>(string("abc"), char(','));
         let err = p.parse("ab,abc")
                    .map(|x| format!("{:?}", x))
                    .unwrap_err();
@@ -397,7 +397,7 @@ Expected 'integer', 'identifier', '[' or '('
 
     #[test]
     fn inner_error_consume() {
-        let mut p = many::<Vec<_>, _>(between(char('['), char(']'), digit()));
+        let mut p = many::<Vec<_>, _, _>(between(char('['), char(']'), digit()));
         let result = p.parse("[1][2][]");
         assert!(result.is_err(), format!("{:?}", result));
         let error = result.map(|x| format!("{:?}", x))
@@ -416,7 +416,7 @@ Expected 'integer', 'identifier', '[' or '('
 
     #[test]
     fn unsized_parser() {
-        let mut parser: Box<Parser<Input = &str, Output = char>> = Box::new(digit());
+        let mut parser: Box<Parser<&str, Output = char>> = Box::new(digit());
         let borrow_parser = &mut *parser;
         assert_eq!(borrow_parser.parse("1"), Ok(('1', "")));
     }

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -829,18 +829,13 @@ impl Positioner for u8 {
 ///All methods have a default implementation but there needs to be at least an implementation of
 ///`parse_state` or`parse_lazy`. If `parse_lazy` is implemented an implementation of `add_error` is
 ///also recommended to improve error reporting.
-pub trait Parser {
-    ///The type which is take as input for the parser. The type must implement the `Stream` trait
-    ///which allows the parser to read item from the type.
-    type Input: Stream;
+pub trait Parser<Input> where Input: Stream {
     ///The type which is returned if the parser is successful.
     type Output;
 
     ///Entrypoint of the parser
     ///Takes some input and tries to parse it returning a `ParseResult`
-    fn parse(&mut self,
-             input: Self::Input)
-             -> Result<(Self::Output, Self::Input), ParseError<Self::Input>> {
+    fn parse(&mut self, input: Input) -> Result<(Self::Output, Input), ParseError<Input>> {
         match self.parse_state(State::new(input)) {
             Ok((v, state)) => Ok((v, state.into_inner().input)),
             Err(error) => Err(error.into_inner()),
@@ -849,7 +844,7 @@ pub trait Parser {
 
     ///Parses using the state `input` by calling Stream::uncons one or more times
     ///On success returns `Ok((value, new_state))` on failure it returns `Err(error)`
-    fn parse_state(&mut self, input: State<Self::Input>) -> ParseResult<Self::Output, Self::Input> {
+    fn parse_state(&mut self, input: State<Input>) -> ParseResult<Self::Output, Input> {
         let mut result = self.parse_lazy(input.clone());
         if let Err(Consumed::Empty(ref mut error)) = result {
             if let Ok((t, _)) = input.input.uncons() {
@@ -863,18 +858,17 @@ pub trait Parser {
     ///Specialized version of parse_state where the parser does not need to add an error to the
     ///`ParseError` when it does not consume any input before encountering the error.
     ///Instead the error can be added later through the `add_error` method
-    fn parse_lazy(&mut self, input: State<Self::Input>) -> ParseResult<Self::Output, Self::Input> {
+    fn parse_lazy(&mut self, input: State<Input>) -> ParseResult<Self::Output, Input> {
         self.parse_state(input)
     }
 
     ///Adds the first error that would normally be returned by this parser if it failed
-    fn add_error(&mut self, _error: &mut ParseError<Self::Input>) {}
+    fn add_error(&mut self, _error: &mut ParseError<Input>) {}
 }
-impl<'a, I, O, P: ?Sized> Parser for &'a mut P
+impl<'a, I, O, P: ?Sized> Parser<I> for &'a mut P
     where I: Stream,
-          P: Parser<Input = I, Output = O>
+          P: Parser<I, Output = O>
 {
-    type Input = I;
     type Output = O;
     fn parse_state(&mut self, input: State<I>) -> ParseResult<O, I> {
         (**self).parse_state(input)
@@ -882,15 +876,14 @@ impl<'a, I, O, P: ?Sized> Parser for &'a mut P
     fn parse_lazy(&mut self, input: State<I>) -> ParseResult<O, I> {
         (**self).parse_lazy(input)
     }
-    fn add_error(&mut self, error: &mut ParseError<Self::Input>) {
+    fn add_error(&mut self, error: &mut ParseError<I>) {
         (**self).add_error(error)
     }
 }
-impl<I, O, P: ?Sized> Parser for Box<P>
+impl<I, O, P: ?Sized> Parser<I> for Box<P>
     where I: Stream,
-          P: Parser<Input = I, Output = O>
+          P: Parser<I, Output = O>
 {
-    type Input = I;
     type Output = O;
     fn parse_state(&mut self, input: State<I>) -> ParseResult<O, I> {
         (**self).parse_state(input)
@@ -898,7 +891,7 @@ impl<I, O, P: ?Sized> Parser for Box<P>
     fn parse_lazy(&mut self, input: State<I>) -> ParseResult<O, I> {
         (**self).parse_lazy(input)
     }
-    fn add_error(&mut self, error: &mut ParseError<Self::Input>) {
+    fn add_error(&mut self, error: &mut ParseError<I>) {
         (**self).add_error(error)
     }
 }

--- a/tests/date.rs
+++ b/tests/date.rs
@@ -37,7 +37,7 @@ fn two_digits_to_int((x, y): (char, char)) -> i32 {
 
 // Parsers which are used frequntly can be wrapped like this to avoid writing parser(fn_name) in
 // several places.
-fn two_digits<I>() -> FnParser<I, fn(State<I>) -> ParseResult<i32, I>>
+fn two_digits<I>() -> FnParser<fn(State<I>) -> ParseResult<i32, I>>
     where I: Stream<Item = char>
 {
     fn two_digits_<I>(input: State<I>) -> ParseResult<i32, I>
@@ -80,7 +80,7 @@ fn time_zone<I>(input: State<I>) -> ParseResult<i32, I>
 fn date<I>(input: State<I>) -> ParseResult<Date, I>
     where I: Stream<Item = char>
 {
-    (many::<String, _>(digit()),
+    (many::<String, _, _>(digit()),
      char('-'),
      two_digits(),
      char('-'),


### PR DESCRIPTION
…ted type

I am not convinced this is the best way to do it after all as unfortunately type inference fails for parsers such as Satisfy and Token when their <I> parameter were removed which were one of the main reasons for doing this