### PR TITLE
Prefer Clone to Copy. Fixes #74.

### DIFF
--- a/src/combinator.rs
+++ b/src/combinator.rs
@@ -2093,4 +2093,18 @@ mod tests {
                        errors: vec![Error::Unexpected('a'.into()), Error::Expected("digit".into())],
                    }));
     }
+
+    #[derive(Clone, PartialEq, Debug)]
+    struct CloneOnly {
+        s: String,
+    }
+
+    #[test]
+    fn token_clone_but_not_copy() {
+        // Verify we can use token() with a StreamSlice with an item type that is Clone but not
+        // Copy.
+        let input = &[CloneOnly { s: "x".to_string() }, CloneOnly { s: "y".to_string() }][..];
+        let result = token(CloneOnly { s: "x".to_string() }).parse(input);
+        assert_eq!(result, Ok((CloneOnly { s: "x".to_string() }, &[CloneOnly { s: "y".to_string() }][..])));
+    }
 }

--- a/src/range.rs
+++ b/src/range.rs
@@ -183,6 +183,16 @@ mod tests {
     fn take_while_test() {
         let result = take_while(|c: char| c.is_digit(10)).parse("123abc");
         assert_eq!(result, Ok(("123", "abc")));
+        let result = take_while(|c: char| c.is_digit(10)).parse("abc");
+        assert_eq!(result, Ok(("", "abc")));
+    }
+
+    #[test]
+    fn take_while1_test() {
+        let result = take_while1(|c: char| c.is_digit(10)).parse("123abc");
+        assert_eq!(result, Ok(("123", "abc")));
+        let result = take_while1(|c: char| c.is_digit(10)).parse("abc");
+        assert!(result.is_err());
     }
 
     #[test]


### PR DESCRIPTION
Together, these commits address the cases I asked about in #74 and #75.  With these, `SliceStream` consumers can use `token()`; and consumers who want a `T` item type can parse non-`Copy` tokens.