### PR TITLE
Add map functions for Error<> and Info<> ranges. (#86)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -504,12 +504,12 @@ mod tests {
         #[derive(Debug)]
         struct ExtractedError(usize, DisplayVec<Error<CloneOnly, DisplayVec<CloneOnly>>>);
 
-        impl std::error::Error for ExtractedError {
+        impl StdError for ExtractedError {
             fn description(&self) -> &str {
                 "extracted error"
             }
         }
-  
+
         impl fmt::Display for CloneOnly {
             fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 write!(f, "{}", self.0)
@@ -534,7 +534,11 @@ mod tests {
             .parse(input)
             .map_err(|e| e.translate_position(input))
             .map_err(|e| {
-                ExtractedError(e.position, DisplayVec(e.errors.into_iter().map(|e| e.map_range(|r| DisplayVec(r.to_owned()))).collect()))
+                ExtractedError(e.position,
+                               DisplayVec(e.errors
+                                   .into_iter()
+                                   .map(|e| e.map_range(|r| DisplayVec(r.to_owned())))
+                                   .collect()))
             });
 
         assert!(result.is_err());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -483,4 +483,69 @@ mod tests {
             err
         });
     }
+
+    #[test]
+    fn extract_std_error() {
+        // The previous test verified that we could map a ParseError to a StdError by dropping the
+        // internal error details.  This test verifies that we can map a ParseError to a StdError
+        // without dropping the internal error details.  Consumers using `error-chain` will
+        // appreciate this.  For technical reasons this is pretty janky; see the discussion in
+        // https://github.com/Marwes/combine/issues/86, and excuse the test with significant
+        // boilerplate!
+        use std::fmt;
+        use std::error::Error as StdError;
+
+        #[derive(Clone, PartialEq, Debug)]
+        struct CloneOnly(String);
+
+        #[derive(Debug)]
+        struct DisplayVec<T>(Vec<T>);
+
+        #[derive(Debug)]
+        struct ExtractedError(usize, DisplayVec<Error<CloneOnly, DisplayVec<CloneOnly>>>);
+
+        impl std::error::Error for ExtractedError {
+            fn description(&self) -> &str {
+                "extracted error"
+            }
+        }
+  
+        impl fmt::Display for CloneOnly {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                write!(f, "{}", self.0)
+            }
+        }
+
+        impl<T: fmt::Debug> fmt::Display for DisplayVec<T> {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                write!(f, "[{:?}]", self.0)
+            }
+        }
+
+        impl fmt::Display for ExtractedError {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                try!(writeln!(f, "Parse error at {}", self.0));
+                Error::fmt_errors(&(self.1).0, f)
+            }
+        }
+
+        let input = &[CloneOnly("x".to_string()), CloneOnly("y".to_string())][..];
+        let result = token(CloneOnly("z".to_string()))
+            .parse(input)
+            .map_err(|e| e.translate_position(input))
+            .map_err(|e| {
+                ExtractedError(e.position, DisplayVec(e.errors.into_iter().map(|e| e.map_range(|r| DisplayVec(r.to_owned()))).collect()))
+            });
+
+        assert!(result.is_err());
+        // Test that the fresh ExtractedError is Display, so that the internal errors can be
+        // inspected by consuming code; and that the ExtractedError can be coerced to StdError.
+        let _ = result.map_err(|err| {
+            let s = format!("{}", err);
+            assert!(s.starts_with("Parse error at 0"));
+            assert!(s.contains("Expected"));
+            let err: Box<StdError> = Box::new(err);
+            err
+        });
+    }
 }

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -57,6 +57,16 @@ pub enum Info<T, R> {
 }
 
 impl<T, R> Info<T, R> {
+    pub fn map_token<F, U>(self, f: F) -> Info<U, R> where F: FnOnce(T) -> U {
+        use self::Info::*;
+        match self {
+            Token(t) => Token(f(t)),
+            Range(r) => Range(r),
+            Owned(s) => Owned(s),
+            Borrowed(x) => Borrowed(x),
+        }
+    }
+
     pub fn map_range<F, S>(self, f: F) -> Info<T, S> where F: FnOnce(R) -> S {
         use self::Info::*;
         match self {
@@ -123,7 +133,17 @@ pub enum Error<T, R> {
 }
 
 impl<T, R> Error<T, R> {
-    pub fn map_err_range<F, S>(self, f: F) -> Error<T, S> where F: FnOnce(R) -> S {
+    pub fn map_token<F, U>(self, f: F) -> Error<U, R> where F: FnOnce(T) -> U {
+        use self::Error::*;
+        match self {
+            Unexpected(x) => Unexpected(x.map_token(f)),
+            Expected(x) => Expected(x.map_token(f)),
+            Message(x) => Message(x.map_token(f)),
+            Other(x) => Other(x),
+        }
+    }
+
+    pub fn map_range<F, S>(self, f: F) -> Error<T, S> where F: FnOnce(R) -> S {
         use self::Error::*;
         match self {
             Unexpected(x) => Unexpected(x.map_range(f)),


### PR DESCRIPTION
It's possible to `map_err_range` for `ParseResult<>` too, but it's
awkward because the output type needs to be a compatible `StreamOnce`.
As suggested in
https://github.com/Marwes/combine/issues/86#issuecomment-280487165,
it's probably best to either change the parse result type entirely, or
wait for https://github.com/rust-lang/rust/issues/21903.

This at least helps consumers convert `ParseError<>` into something
that can implement `std::fmt::Display`.