### PR TITLE
Add `exactly(p)` for parsing `p` followed by `eof()`.

### DIFF
--- a/src/combinator.rs
+++ b/src/combinator.rs
@@ -1357,6 +1357,37 @@ pub fn optional<P>(parser: P) -> Optional<P>
     Optional(parser)
 }
 
+impl_parser! { Exactly(P,), Map<(P, Eof<P::Input>), fn ((P::Output, ())) -> P::Output> }
+/// Parses `parser` followed by `eof()`
+/// Returns the value of `parser`.
+///
+/// ```
+/// # extern crate combine;
+/// # use combine::*;
+/// # use combine::char::string;
+/// # use combine::primitives::{Error, Positioner, SourcePosition};
+/// # fn main() {
+/// let mut parser = exactly(string("rust"));
+/// assert_eq!(parser.parse(State::new("rust")),
+///     Ok(("rust", State { position: SourcePosition { line: 1, column: 5 }, input: "" })));
+/// assert_eq!(parser.parse(State::new("rust!")), Err(ParseError {
+///     position: SourcePosition { line: 1, column: 5 },
+///     errors: vec![
+///         Error::Unexpected('!'.into()),
+///         Error::Expected("end of input".into())
+///     ]
+/// }));
+/// # }
+/// ```
+#[inline(always)]
+pub fn exactly<I, P>(parser: P) -> Exactly<P>
+    where I: Stream,
+          P: Parser<Input = I>
+{
+    fn first<T>(pair: (T, ())) -> T { pair.0 }
+    Exactly((parser, eof()).map(first))
+}
+
 impl_parser! { Between(L, R, P), Skip<With<L, P>, R> }
 /// Parses `open` followed by `parser` followed by `close`
 /// Returns the value of `parser`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,10 +139,10 @@
 pub use primitives::{Parser, ParseError, ConsumedResult, ParseResult, State, from_iter, Stream,
                      StreamOnce};
 #[doc(inline)]
-pub use combinator::{any, between, chainl1, chainr1, choice, count, eof, env_parser, many, many1,
-                     none_of, one_of, optional, parser, position, satisfy, satisfy_map, sep_by,
-                     sep_by1, sep_end_by, sep_end_by1, skip_many, skip_many1, token, tokens, try,
-                     look_ahead, value, unexpected, not_followed_by};
+pub use combinator::{any, between, chainl1, chainr1, choice, count, eof, env_parser, exactly, many,
+                     many1, none_of, one_of, optional, parser, position, satisfy, satisfy_map,
+                     sep_by, sep_by1, sep_end_by, sep_end_by1, skip_many, skip_many1, token, tokens,
+                     try, look_ahead, value, unexpected, not_followed_by};
 
 macro_rules! static_fn {
     (($($arg: pat, $arg_ty: ty),*) -> $ret: ty { $body: expr }) => { {


### PR DESCRIPTION
When parsing JSON-like values, we frequently to need to parse a list
or other sub-structure of finite length.  We end up with many
instances of `(p, eof()).map(|x| x.0)`; this will express those
cleanly.