### PR TITLE
Fix `Message` so it always adds its message

### DIFF
--- a/src/combinator.rs
+++ b/src/combinator.rs
@@ -1675,7 +1675,7 @@ impl<I, P> Parser for Message<P>
 
     #[inline]
     fn parse_lazy(&mut self, input: I) -> ConsumedResult<Self::Output, I> {
-        match self.0.parse_lazy(input.clone()) {
+        match self.0.parse_lazy(input) {
             ConsumedOk(x) => ConsumedOk(x),
             EmptyOk(x) => EmptyOk(x),
 


### PR DESCRIPTION
Fix to `message` issue we were discussing on gitter earlier.

Add a unit test checking for the issue.