### PR TITLE
Fixes to `try` and `expected`

### DIFF
--- a/tests/ini.rs
+++ b/tests/ini.rs
@@ -20,7 +20,7 @@ fn property<I>(input: I) -> ParseResult<(String, String), I>
      token('='),
      many1(satisfy(|c| c != '\n' && c != ';')))
         .map(|(key, _, value)| (key, value))
-        .expected("property")
+        .message("while parsing property")
         .parse_stream(input)
 }
 
@@ -47,7 +47,7 @@ fn section<I>(input: I) -> ParseResult<(String, HashMap<String, String>), I>
      parser(whitespace),
      parser(properties))
         .map(|(name, _, properties)| (name, properties))
-        .expected("section")
+        .message("while parsing section")
         .parse_stream(input)
 }
 
@@ -105,7 +105,8 @@ fn ini_error() {
                    },
                    errors: vec![
             Error::end_of_input(),
-            Error::Expected("section".into()),
+            Error::Expected(']'.into()),
+            Error::Message("while parsing section".into()),
         ],
                }));
 }


### PR DESCRIPTION
* `try` used to report errors twice in some cases. Fix that.

* Change `expected` in the same way as `message` from earlier.  
Regarding your comment earlier: I would expect `(expr, operator, expr).expected("binary expression").parse("1")` to output "expected binary expression"... Can you tell me why you think this is wrong?  
Also, doesn't `message` fulfil the role of `context` as you've described it previously?



Both have unit tests (which have illustrative failures pre-fixes)