### PR TITLE
Issue 99

### DIFF
--- a/benches/http.rs
+++ b/benches/http.rs
@@ -42,7 +42,11 @@ fn is_http_version(c: u8) -> bool {
 
 fn parse_http_request(input: &[u8]) -> Result<((Request, Vec<Header>), &[u8]), ParseError<&[u8]>> {
     // Making a closure, because parser instances cannot be reused
-    let end_of_line = || (token(b'\r'), token(b'\n')).map(|_| b'\r').or(token(b'\n'));
+    let end_of_line = || {
+        (token(b'\r'), token(b'\n'))
+            .map(|_| b'\r')
+            .or(token(b'\n'))
+    };
 
     let http_version = range(&b"HTTP/"[..]).with(take_while1(is_http_version));
 
@@ -52,12 +56,12 @@ fn parse_http_request(input: &[u8]) -> Result<((Request, Vec<Header>), &[u8]), P
                         take_while1(is_space),
                         http_version)
             .map(|(method, _, uri, _, version)| {
-                Request {
-                    method: method,
-                    uri: uri,
-                    version: version,
-                }
-            });
+                     Request {
+                         method: method,
+                         uri: uri,
+                         version: version,
+                     }
+                 });
 
 
     let message_header_line = (take_while1(is_horizontal_space),

--- a/src/char.rs
+++ b/src/char.rs
@@ -187,7 +187,9 @@ impl<I> Parser for Str<I>
     type Output = &'static str;
     #[inline]
     fn parse_lazy(&mut self, input: Self::Input) -> ConsumedResult<Self::Output, Self::Input> {
-        tokens(eq, self.0.into(), self.0.chars()).parse_lazy(input).map(|_| self.0)
+        tokens(eq, self.0.into(), self.0.chars())
+            .parse_lazy(input)
+            .map(|_| self.0)
     }
     fn add_error(&mut self, errors: &mut ParseError<Self::Input>) {
         tokens(eq, self.0.into(), self.0.chars()).add_error(errors)
@@ -224,7 +226,9 @@ impl<C, I> Parser for StrCmp<C, I>
     type Output = &'static str;
     #[inline]
     fn parse_lazy(&mut self, input: Self::Input) -> ConsumedResult<Self::Output, Self::Input> {
-        tokens(&mut self.1, self.0.into(), self.0.chars()).parse_lazy(input).map(|_| self.0)
+        tokens(&mut self.1, self.0.into(), self.0.chars())
+            .parse_lazy(input)
+            .map(|_| self.0)
     }
     fn add_error(&mut self, errors: &mut ParseError<Self::Input>) {
         tokens(&mut self.1, self.0.into(), self.0.chars()).add_error(errors)
@@ -272,10 +276,7 @@ mod tests {
         let result = string("a").parse(State::new("b"));
         assert!(result.is_err());
         assert_eq!(result.unwrap_err().position,
-                   SourcePosition {
-                       line: 1,
-                       column: 1,
-                   });
+                   SourcePosition { line: 1, column: 1 });
     }
 
     #[test]
@@ -283,10 +284,7 @@ mod tests {
         let result = string("abc").parse(State::new("bc"));
         assert_eq!(result,
                    Err(ParseError {
-                           position: SourcePosition {
-                               line: 1,
-                               column: 1,
-                           },
+                           position: SourcePosition { line: 1, column: 1 },
                            errors: vec![Error::Unexpected('b'.into()),
                                         Error::Expected("abc".into())],
                        }));

--- a/src/combinator.rs
+++ b/src/combinator.rs
@@ -45,7 +45,7 @@ impl<I> Parser for Any<I>
         let position = input.position();
         match input.uncons() {
             Ok(x) => ConsumedOk((x, input)),
-            Err(err) => ConsumedErr(ParseError::new(position, err)),
+            Err(err) => EmptyErr(ParseError::new(position, err)),
         }
     }
 }
@@ -2237,5 +2237,10 @@ mod tests {
         assert_eq!(consumed0.parse(State::new(input)), consumed_expected);
         assert_eq!(consumed1.parse(State::new(input)), consumed_expected);
         assert_eq!(consumed2.parse(State::new(input)), consumed_expected);
+    }
+
+    #[test]
+    fn issue_99() {
+        assert!(any().map(|_| ()).or(eof()).parse("").is_ok());
     }
 }

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -7,8 +7,8 @@ use std::io::{Read, Bytes};
 
 use self::FastResult::*;
 
-use combinator::{AndThen, and_then, Expected, expected, FlatMap, flat_map, Iter, Map, map, Message,
-                 message, Or, or, Skip, skip, Then, then, With, with};
+use combinator::{AndThen, and_then, Expected, expected, FlatMap, flat_map, Iter, Map, map,
+                 Message, message, Or, or, Skip, skip, Then, then, With, with};
 
 #[macro_export]
 macro_rules! ctry {
@@ -217,10 +217,12 @@ impl<T, R> Error<T, R> {
         // First print the token that we did not expect
         // There should really just be one unexpected message at this point though we print them
         // all to be safe
-        let unexpected = errors.iter().filter(|e| match **e {
-                                                  Error::Unexpected(_) => true,
-                                                  _ => false,
-                                              });
+        let unexpected = errors
+            .iter()
+            .filter(|e| match **e {
+                        Error::Unexpected(_) => true,
+                        _ => false,
+                    });
         for error in unexpected {
             try!(writeln!(f, "{}", error));
         }
@@ -228,10 +230,12 @@ impl<T, R> Error<T, R> {
         // Then we print out all the things that were expected in a comma separated list
         // 'Expected 'a', 'expression' or 'let'
         let iter = || {
-            errors.iter().filter_map(|e| match *e {
-                                         Error::Expected(ref err) => Some(err),
-                                         _ => None,
-                                     })
+            errors
+                .iter()
+                .filter_map(|e| match *e {
+                                Error::Expected(ref err) => Some(err),
+                                _ => None,
+                            })
         };
         let expected_count = iter().count();
         for (i, message) in iter().enumerate() {
@@ -247,11 +251,13 @@ impl<T, R> Error<T, R> {
             try!(writeln!(f, ""));
         }
         // If there are any generic messages we print them out last
-        let messages = errors.iter().filter(|e| match **e {
-                                                Error::Message(_) |
-                                                Error::Other(_) => true,
-                                                _ => false,
-                                            });
+        let messages = errors
+            .iter()
+            .filter(|e| match **e {
+                        Error::Message(_) |
+                        Error::Other(_) => true,
+                        _ => false,
+                    });
         for error in messages {
             try!(writeln!(f, "{}", error));
         }
@@ -476,10 +482,11 @@ impl<S: StreamOnce> ParseError<S> {
     /// Remvoes all `Expected` errors in `self` and adds `info` instead.
     pub fn set_expected(&mut self, info: Info<S::Item, S::Range>) {
         // Remove all other expected messages
-        self.errors.retain(|e| match *e {
-                               Error::Expected(_) => false,
-                               _ => true,
-                           });
+        self.errors
+            .retain(|e| match *e {
+                        Error::Expected(_) => false,
+                        _ => true,
+                    });
         self.errors.push(Error::Expected(info));
     }
 
@@ -677,10 +684,12 @@ impl<I, E> RangeStream for State<I>
     #[inline]
     fn uncons_range(&mut self, size: usize) -> Result<I::Range, Error<I::Item, I::Range>> {
         let position = &mut self.position;
-        self.input.uncons_range(size).map(|value| {
-                                              value.update(position);
-                                              value
-                                          })
+        self.input
+            .uncons_range(size)
+            .map(|value| {
+                     value.update(position);
+                     value
+                 })
     }
 
     #[inline]
@@ -688,12 +697,13 @@ impl<I, E> RangeStream for State<I>
         where F: FnMut(I::Item) -> bool
     {
         let position = &mut self.position;
-        self.input.uncons_while(|t| if predicate(t.clone()) {
-                                    t.update(position);
-                                    true
-                                } else {
-                                    false
-                                })
+        self.input
+            .uncons_while(|t| if predicate(t.clone()) {
+                              t.update(position);
+                              true
+                          } else {
+                              false
+                          })
     }
 }
 
@@ -735,7 +745,9 @@ pub fn uncons<I>(mut input: I) -> ParseResult<I::Item, I>
     where I: Stream
 {
     let position = input.position();
-    let x = try!(input.uncons().map_err(|err| Consumed::Empty(ParseError::new(position, err))));
+    let x = try!(input
+                     .uncons()
+                     .map_err(|err| Consumed::Empty(ParseError::new(position, err))));
     Ok((x, Consumed::Consumed(input)))
 }
 
@@ -962,10 +974,7 @@ impl<'a, T> RangeStream for SliceStream<'a, T>
     fn uncons_while<F>(&mut self, mut f: F) -> Result<&'a [T], Error<&'a T, &'a [T]>>
         where F: FnMut(Self::Item) -> bool
     {
-        let len = self.0
-            .iter()
-            .take_while(|c| f(*c))
-            .count();
+        let len = self.0.iter().take_while(|c| f(*c)).count();
         let (range, rest) = self.0.split_at(len);
         self.0 = rest;
         Ok(range)
@@ -1143,10 +1152,7 @@ impl Positioner for str {
 impl Positioner for char {
     type Position = SourcePosition;
     fn start() -> SourcePosition {
-        SourcePosition {
-            line: 1,
-            column: 1,
-        }
+        SourcePosition { line: 1, column: 1 }
     }
     fn update(&self, position: &mut SourcePosition) {
         position.column += 1;
@@ -1825,7 +1831,9 @@ impl<I> BufferedStreamInner<I>
             // We have backtracked to far
             Err(Error::Message("Backtracked to far".into()))
         } else {
-            Ok(self.buffer[self.buffer.len() - (self.offset - offset)].0.clone())
+            Ok(self.buffer[self.buffer.len() - (self.offset - offset)]
+                   .0
+                   .clone())
         }
     }
 
@@ -1840,7 +1848,9 @@ impl<I> BufferedStreamInner<I>
                 .1
                 .clone()
         } else {
-            self.buffer[self.buffer.len() - (self.offset - offset)].1.clone()
+            self.buffer[self.buffer.len() - (self.offset - offset)]
+                .1
+                .clone()
         }
     }
 }
@@ -1928,7 +1938,9 @@ mod tests {
     #[test]
     fn parse_clone_but_not_copy() {
         // This verifies we can parse slice references with an item type that is Clone but not Copy.
-        let input = &[CloneOnly { s: "x".to_string() }, CloneOnly { s: "y".to_string() }][..];
+        let input = &[CloneOnly { s: "x".to_string() },
+                      CloneOnly { s: "y".to_string() }]
+                         [..];
         let result = ::range::take_while(|c: CloneOnly| c.s == "x".to_string()).parse(input);
         assert_eq!(result,
                    Ok((&[CloneOnly { s: "x".to_string() }][..],

--- a/tests/buffered_stream.rs
+++ b/tests/buffered_stream.rs
@@ -7,15 +7,19 @@ use combine::{StreamOnce, Parser, choice, from_iter, many, many1, sep_by, try};
 #[test]
 fn shared_stream_buffer() {
     // Iterator that can't be cloned
-    let text = "10,222,3,44".chars().map(|c| if c.is_digit(10) {
-                                             (c as u8 + 1) as char
-                                         } else {
-                                             c
-                                         });
+    let text = "10,222,3,44"
+        .chars()
+        .map(|c| if c.is_digit(10) {
+                 (c as u8 + 1) as char
+             } else {
+                 c
+             });
     let buffer = BufferedStream::new(from_iter(text), 1);
     let int: &mut Parser<Input = _, Output = _> =
         &mut many(digit()).map(|s: String| s.parse::<i64>().unwrap());
-    let result = sep_by(int, char(',')).parse(buffer.as_stream()).map(|t| t.0);
+    let result = sep_by(int, char(','))
+        .parse(buffer.as_stream())
+        .map(|t| t.0);
     assert_eq!(result, Ok(vec![21, 333, 4, 55]));
 }
 
@@ -27,8 +31,9 @@ fn shared_stream_backtrack() {
     let buffer = BufferedStream::new(from_iter(&mut iter), 2);
     let stream = buffer.as_stream();
 
-    let value: &mut Parser<Input = _, Output = _> =
-        &mut choice([try(string("apple")), try(string("orange")), try(string("ananas"))]);
+    let value: &mut Parser<Input = _, Output = _> = &mut choice([try(string("apple")),
+                                                                 try(string("orange")),
+                                                                 try(string("ananas"))]);
     let mut parser = sep_by(value, char(','));
     let result = parser.parse(stream).map(|t| t.0);
     assert_eq!(result, Ok(vec!["apple", "apple", "ananas", "orange"]));
@@ -42,12 +47,14 @@ fn shared_stream_insufficent_backtrack() {
     let buffer = BufferedStream::new(from_iter(&mut iter), 1);
     let stream = buffer.as_stream();
 
-    let value: &mut Parser<Input = _, Output = _> =
-        &mut choice([try(string("apple")), try(string("orange")), try(string("ananas"))]);
+    let value: &mut Parser<Input = _, Output = _> = &mut choice([try(string("apple")),
+                                                                 try(string("orange")),
+                                                                 try(string("ananas"))]);
     let mut parser = sep_by(value, char(','));
     let result: Result<Vec<&str>, _> = parser.parse(stream).map(|t| t.0);
     assert!(result.is_err());
-    assert!(result.unwrap_err()
+    assert!(result
+                .unwrap_err()
                 .errors
                 .iter()
                 .any(|err| *err == Error::Message("Backtracked to far".into())));
@@ -60,7 +67,9 @@ fn always_output_end_of_input_after_end_of_input() {
     let text = "10".chars();
     let buffer = BufferedStream::new(from_iter(text), 1);
     let int = many1(digit()).map(|s: String| s.parse::<i64>().unwrap());
-    let result = many(spaces().with(int)).parse(buffer.as_stream()).map(|t| t.0);
+    let result = many(spaces().with(int))
+        .parse(buffer.as_stream())
+        .map(|t| t.0);
     assert_eq!(result, Ok(vec![10]));
 }
 

--- a/tests/date.rs
+++ b/tests/date.rs
@@ -45,7 +45,9 @@ fn two_digits<I>() -> FnPtrParser<i32, I>
     fn two_digits_<I>(input: I) -> ParseResult<i32, I>
         where I: Stream<Item = char>
     {
-        (digit(), digit()).map(two_digits_to_int).parse_stream(input)
+        (digit(), digit())
+            .map(two_digits_to_int)
+            .parse_stream(input)
     }
     parser(two_digits_)
 }
@@ -77,13 +79,13 @@ fn date<I>(input: I) -> ParseResult<Date, I>
 {
     (many::<String, _>(digit()), char('-'), two_digits(), char('-'), two_digits())
         .map(|(year, _, month, _, day)| {
-            // Its ok to just unwrap since we only parsed digits
-            Date {
-                year: year.parse().unwrap(),
-                month: month,
-                day: day,
-            }
-        })
+                 // Its ok to just unwrap since we only parsed digits
+                 Date {
+                     year: year.parse().unwrap(),
+                     month: month,
+                     day: day,
+                 }
+             })
         .parse_stream(input)
 }
 

--- a/tests/ini.rs
+++ b/tests/ini.rs
@@ -78,12 +78,16 @@ type=LL(1)
         global: HashMap::new(),
         sections: HashMap::new(),
     };
-    expected.global.insert(String::from("language"), String::from("rust"));
+    expected
+        .global
+        .insert(String::from("language"), String::from("rust"));
 
     let mut section = HashMap::new();
     section.insert(String::from("name"), String::from("combine"));
     section.insert(String::from("type"), String::from("LL(1)"));
-    expected.sections.insert(String::from("section"), section);
+    expected
+        .sections
+        .insert(String::from("section"), section);
 
     let result = parser(ini).parse(text).map(|t| t.0);
     assert_eq!(result, Ok(expected));
@@ -95,10 +99,7 @@ fn ini_error() {
     let result = parser(ini).parse(State::new(text)).map(|t| t.0);
     assert_eq!(result,
                Err(ParseError {
-                       position: SourcePosition {
-                           line: 1,
-                           column: 7,
-                       },
+                       position: SourcePosition { line: 1, column: 7 },
                        errors: vec![Error::end_of_input(), Error::Expected("section".into())],
                    }));
 }


### PR DESCRIPTION
Since any does not consume anything when failing it should obviously return `EmptyErr`. Luckily it is rare that this bug occurs in practice since it is really only the `any + eof` parser combination which this presents itself in.

Thanks @yubrot for reporting!