### PR TITLE
move from_read into ReadStream impl block

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "combine"
-version = "2.3.2"
+version = "2.4.0"
 authors = ["Markus Westerlind <marwes91@gmail.com>"]
 
 description = "Fast parser combinators on arbitrary streams with zero-copy support."

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,8 +156,14 @@
 #![cfg_attr(feature = "cargo-clippy", allow(inline_always))]
 
 #[doc(inline)]
-pub use primitives::{Parser, ParseError, ConsumedResult, ParseResult, State, from_iter, Stream,
-                     StreamOnce};
+pub use primitives::{Parser, ParseError, ConsumedResult, ParseResult, State, Stream, StreamOnce};
+
+// import this one separately, so we can set the allow(deprecated) for just this item
+// TODO: remove this when a new major version is released
+#[doc(inline)]
+#[allow(deprecated)]
+pub use primitives::from_iter;
+
 #[doc(inline)]
 pub use combinator::{any, between, chainl1, chainr1, choice, count, eof, env_parser, many, many1,
                      none_of, one_of, optional, parser, position, satisfy, satisfy_map, sep_by,
@@ -239,6 +245,7 @@ mod tests {
         assert_eq!(result, Ok((vec![123i64, 4, 56], "")));
     }
     #[test]
+    #[allow(deprecated)]
     fn iterator() {
         let result = parser(integer)
             .parse(from_iter("123".chars()))

--- a/tests/buffered_stream.rs
+++ b/tests/buffered_stream.rs
@@ -2,9 +2,13 @@
 extern crate combine;
 use combine::primitives::{BufferedStream, Error};
 use combine::char::{char, digit, spaces, string};
-use combine::{StreamOnce, Parser, choice, from_iter, many, many1, sep_by, try};
+use combine::{StreamOnce, Parser, choice, many, many1, sep_by, try};
+
+#[allow(deprecated)]
+use combine::from_iter;
 
 #[test]
+#[allow(deprecated)]
 fn shared_stream_buffer() {
     // Iterator that can't be cloned
     let text = "10,222,3,44"
@@ -24,6 +28,7 @@ fn shared_stream_buffer() {
 }
 
 #[test]
+#[allow(deprecated)]
 fn shared_stream_backtrack() {
     let text = "apple,apple,ananas,orangeblah";
     let mut iter = text.chars();
@@ -40,6 +45,7 @@ fn shared_stream_backtrack() {
 }
 
 #[test]
+#[allow(deprecated)]
 fn shared_stream_insufficent_backtrack() {
     let text = "apple,apple,ananas,orangeblah";
     let mut iter = text.chars();
@@ -63,6 +69,7 @@ fn shared_stream_insufficent_backtrack() {
 /// Test which checks that a stream which has ended does not repeat the last token in some cases in
 /// which case this test would loop forever
 #[test]
+#[allow(deprecated)]
 fn always_output_end_of_input_after_end_of_input() {
     let text = "10".chars();
     let buffer = BufferedStream::new(from_iter(text), 1);
@@ -74,6 +81,7 @@ fn always_output_end_of_input_after_end_of_input() {
 }
 
 #[test]
+#[allow(deprecated)]
 fn position() {
     let text = "10abc".chars();
     let buffer = BufferedStream::new(from_iter(text), 3);


### PR DESCRIPTION
this way it shows up in `ReadStream`'s documentation as an associated
method and users are less confused as to how to build a `ReadStream`

i know this breaks API and would therefore only be mergeable for some later release (if you want it at all), but i thought this was the quickest way to suggest this change (quicker/better than to write a lengthy bug report detailing what i mean, at least).