### PR TITLE
docs: Fix some broken links

### DIFF
--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -1350,7 +1350,7 @@ pub trait Parser {
     /// Returns the parsed result and the remaining input if the parser succeeds, or a
     /// [`ParseError`] otherwise.
     ///
-    /// [`ParseError`]: primitives/struct.ParseError.html
+    /// [`ParseError`]: struct.ParseError.html
     fn parse(
         &mut self,
         input: Self::Input,
@@ -1368,7 +1368,7 @@ pub trait Parser {
     /// whether this parser consumed any input data or not.
     ///
     /// [`Stream::uncons`]: trait.StreamOnce.html#tymethod.uncons
-    /// [`Consumed`]: primitives/enum.Consumed.html
+    /// [`Consumed`]: enum.Consumed.html
     #[inline(always)]
     fn parse_stream(&mut self, input: Self::Input) -> ParseResult<Self::Output, Self::Input> {
         self.parse_stream_consumed(input).into()
@@ -1381,8 +1381,8 @@ pub trait Parser {
     ///
     /// [`Stream::uncons`]: trait.StreamOnce.html#tymethod.uncons
     /// [`parse_stream`]: trait.Parser.html#method.parse_stream
-    /// [`Consumed`]: primitives/enum.Consumed.html
-    /// [`FastResult`]: primitives/enum.FastResult.html
+    /// [`Consumed`]: enum.Consumed.html
+    /// [`FastResult`]: enum.FastResult.html
     #[inline]
     fn parse_stream_consumed(
         &mut self,


### PR DESCRIPTION
While reading the documentation I noticed some broken links on `https://docs.rs/combine/2.4.0/combine/primitives/trait.Parser.html`. This PR fixes these broken links.

For completeness I used [linkchecker](https://wummel.github.io/linkchecker/) on https://docs.rs/combine/2.4.0/combine/ to verify that these were the only broken links:

```
LinkChecker 9.3              Copyright (C) 2000-2014 Bastian Kleineidam
LinkChecker comes with ABSOLUTELY NO WARRANTY!
This is free software, and you are welcome to redistribute it
under certain conditions. Look at the file `LICENSE' within this
distribution.
Get the newest version at http://wummel.github.io/linkchecker/
Write comments and bugs to https://github.com/wummel/linkchecker/issues
Support this project at http://wummel.github.io/linkchecker/donations.html

Start checking at 2017-08-05 15:11:16+000

URL        `primitives/struct.ParseError.html'
Name       `ParseError'
Parent URL https://docs.rs/combine/2.4.0/combine/primitives/trait.Parser.html, line 269, col 1
Real URL   https://docs.rs/combine/2.4.0/combine/primitives/primitives/struct.ParseError.html
Check time 3.333 seconds
Size       3KB
Result     Error: 404 Not Found

URL        `primitives/enum.Consumed.html'
Name       `Consumed'
Parent URL https://docs.rs/combine/2.4.0/combine/primitives/trait.Parser.html, line 273, col 74
Real URL   https://docs.rs/combine/2.4.0/combine/primitives/primitives/enum.Consumed.html
Check time 3.380 seconds
Size       3KB
Result     Error: 404 Not Found

URL        `primitives/enum.Consumed.html'
Name       `Consumed'
Parent URL https://docs.rs/combine/2.4.0/combine/primitives/trait.Parser.html, line 278, col 41
Real URL   https://docs.rs/combine/2.4.0/combine/primitives/primitives/enum.Consumed.html
Check time 3.114 seconds
Size       3KB
Result     Error: 404 Not Found

URL        `primitives/enum.FastResult.html'
Name       `FastResult'
Parent URL https://docs.rs/combine/2.4.0/combine/primitives/trait.Parser.html, line 278, col 121
Real URL   https://docs.rs/combine/2.4.0/combine/primitives/primitives/enum.FastResult.html
Check time 2.948 seconds
Size       3KB
Result     Error: 404 Not Found

Statistics:
Downloaded: 1.32MB.
Content types: 0 image, 1076 text, 0 video, 0 audio, 49 application, 0 mail and 5369 other.
URL lengths: min=16, max=92, avg=54.

That's it. 6494 links in 30 URLs checked. 0 warnings found. 4 errors found.
Stopped checking at 2017-08-05 15:11:37+000 (20 seconds)
```