### PR TITLE
feat: Add a macro for declaring parsers

### DIFF
--- a/benches/json.rs
+++ b/benches/json.rs
@@ -10,11 +10,11 @@ use std::path::Path;
 
 use bencher::{black_box, Bencher};
 
-use pc::primitives::{BufferedStream, Consumed, ParseError, ParseResult, Parser, State, Stream};
+use pc::primitives::{BufferedStream, Consumed, IteratorStream, ParseError, ParseResult, Parser,
+                     State, Stream};
 use pc::combinator::{any, between, choice, many, optional, parser, satisfy, sep_by, Expected,
                      FnParser, Skip, many1};
 use pc::char::{char, digit, spaces, string, Spaces};
-use pc::from_iter;
 
 #[derive(PartialEq, Debug)]
 enum Value {
@@ -238,7 +238,7 @@ fn bench_buffered_json(bencher: &mut Bencher) {
         .and_then(|mut file| file.read_to_string(&mut data))
         .unwrap();
     bencher.iter(|| {
-        let buffer = BufferedStream::new(from_iter(data.chars()), 1);
+        let buffer = BufferedStream::new(IteratorStream::new(data.chars()), 1);
         let mut parser = Json::value();
         match parser.parse(State::new(buffer.as_stream())) {
             Ok((Value::Array(v), _)) => {

--- a/src/char.rs
+++ b/src/char.rs
@@ -29,7 +29,7 @@ parser!{
     /// assert_eq!(digit().parse("9"), Ok(('9', "")));
     /// assert!(digit().parse("A").is_err());
     /// ```
-    pub digit[I]()(I) -> char
+    pub fn digit[I]()(I) -> char
     where
         [I: Stream<Item = char>,]
     {

--- a/src/char.rs
+++ b/src/char.rs
@@ -19,8 +19,10 @@ where
     token(c)
 }
 
-pub type Digit<I> = digit::__Parser<I>;
+pub use self::digit::Digit;
 parser!{
+    #[derive(Clone)]
+    pub struct Digit;
     /// Parses a base-10 digit.
     ///
     /// ```

--- a/src/char.rs
+++ b/src/char.rs
@@ -19,7 +19,7 @@ where
     token(c)
 }
 
-pub type Digit<I> = digit::P<I>;
+pub type Digit<I> = digit::__Parser<I>;
 parser!{
     /// Parses a base-10 digit.
     ///
@@ -29,7 +29,7 @@ parser!{
     /// assert_eq!(digit().parse("9"), Ok(('9', "")));
     /// assert!(digit().parse("A").is_err());
     /// ```
-    pub digit[I](I) -> char
+    pub digit[I]()(I) -> char
     where
         [I: Stream<Item = char>,]
     {

--- a/src/char.rs
+++ b/src/char.rs
@@ -2,6 +2,7 @@ use primitives::{ConsumedResult, ParseError, Parser, Stream};
 use combinator::{satisfy, skip_many, token, tokens, Expected, Satisfy, SkipMany, Token, With};
 use std::marker::PhantomData;
 
+
 /// Parses a character and succeeds if the character is equal to `c`.
 ///
 /// ```
@@ -18,25 +19,22 @@ where
     token(c)
 }
 
-impl_token_parser! { Digit(), char, Expected<Satisfy<I, fn (char) -> bool>> }
-
-/// Parses a base-10 digit.
-///
-/// ```
-/// use combine::Parser;
-/// use combine::char::digit;
-/// assert_eq!(digit().parse("9"), Ok(('9', "")));
-/// assert!(digit().parse("A").is_err());
-/// ```
-#[inline(always)]
-pub fn digit<I>() -> Digit<I>
-where
-    I: Stream<Item = char>,
-{
-    Digit(
-        satisfy(static_fn!((c, char) -> bool { c.is_digit(10) })).expected("digit"),
-        PhantomData,
-    )
+pub type Digit<I> = digit::P<I>;
+parser!{
+    /// Parses a base-10 digit.
+    ///
+    /// ```
+    /// use combine::Parser;
+    /// use combine::char::digit;
+    /// assert_eq!(digit().parse("9"), Ok(('9', "")));
+    /// assert!(digit().parse("A").is_err());
+    /// ```
+    pub digit[I](I) -> char
+    where
+        [I: Stream<Item = char>,]
+    {
+        satisfy(|c: char| c.is_digit(10)).expected("digit")
+    }
 }
 
 impl_token_parser! { Space(), char, Expected<Satisfy<I, fn (char) -> bool>> }

--- a/src/combinator.rs
+++ b/src/combinator.rs
@@ -1319,68 +1319,6 @@ impl<'a, I: Stream, O> Parser for FnMut(I) -> ParseResult<O, I> + 'a {
 }
 
 #[derive(Clone)]
-pub struct LazyParser<I, F, G>(F, G, PhantomData<fn(I) -> I>);
-
-impl<I, O, F, G> Parser for LazyParser<I, F, G>
-where
-    I: Stream,
-    F: FnMut(I) -> ConsumedResult<O, I>,
-    G: FnMut(&mut ParseError<I>),
-{
-    type Input = I;
-    type Output = O;
-    fn parse_lazy(&mut self, input: I) -> ConsumedResult<O, I> {
-        (self.0)(input)
-    }
-
-    fn add_error(&mut self, errors: &mut ParseError<Self::Input>) {
-        (self.1)(errors)
-    }
-}
-
-
-/// Wraps a function, turning it into a parser.
-///
-/// Mainly used through the `parser!` macro.
-///
-/// ```
-/// extern crate combine;
-/// # use combine::*;
-/// # use combine::char::digit;
-/// # use combine::primitives::{Consumed, Error};
-/// # fn main() {
-/// let mut even_digit = parser(|input| {
-///     // Help type inference out
-///     let _: &str = input;
-///     let position = input.position();
-///     let (char_digit, input) = try!(digit().parse_stream(input));
-///     let d = (char_digit as i32) - ('0' as i32);
-///     if d % 2 == 0 {
-///         Ok((d, input))
-///     }
-///     else {
-///         //Return an empty error since we only tested the first token of the stream
-///         let errors = ParseError::new(position, Error::Expected(From::from("even number")));
-///         Err(Consumed::Empty(errors))
-///     }
-/// });
-/// let result = even_digit
-///     .parse("8")
-///     .map(|x| x.0);
-/// assert_eq!(result, Ok(8));
-/// # }
-/// ```
-#[inline(always)]
-pub fn lazy_parser<I, O, F, G>(parse: F, add_error: G) -> LazyParser<I, F, G>
-where
-    I: Stream,
-    F: FnMut(I) -> ConsumedResult<O, I>,
-    G: FnMut(&mut ParseError<I>),
-{
-    LazyParser(parse, add_error, PhantomData)
-}
-
-#[derive(Clone)]
 pub struct FnParser<I, F>(F, PhantomData<fn(I) -> I>);
 
 /// Wraps a function, turning it into a parser.

--- a/src/combinator.rs
+++ b/src/combinator.rs
@@ -1317,6 +1317,69 @@ impl<'a, I: Stream, O> Parser for FnMut(I) -> ParseResult<O, I> + 'a {
         self(input)
     }
 }
+
+#[derive(Clone)]
+pub struct LazyParser<I, F, G>(F, G, PhantomData<fn(I) -> I>);
+
+impl<I, O, F, G> Parser for LazyParser<I, F, G>
+where
+    I: Stream,
+    F: FnMut(I) -> ConsumedResult<O, I>,
+    G: FnMut(&mut ParseError<I>),
+{
+    type Input = I;
+    type Output = O;
+    fn parse_lazy(&mut self, input: I) -> ConsumedResult<O, I> {
+        (self.0)(input)
+    }
+
+    fn add_error(&mut self, errors: &mut ParseError<Self::Input>) {
+        (self.1)(errors)
+    }
+}
+
+
+/// Wraps a function, turning it into a parser.
+///
+/// Mainly used through the `parser!` macro.
+///
+/// ```
+/// extern crate combine;
+/// # use combine::*;
+/// # use combine::char::digit;
+/// # use combine::primitives::{Consumed, Error};
+/// # fn main() {
+/// let mut even_digit = parser(|input| {
+///     // Help type inference out
+///     let _: &str = input;
+///     let position = input.position();
+///     let (char_digit, input) = try!(digit().parse_stream(input));
+///     let d = (char_digit as i32) - ('0' as i32);
+///     if d % 2 == 0 {
+///         Ok((d, input))
+///     }
+///     else {
+///         //Return an empty error since we only tested the first token of the stream
+///         let errors = ParseError::new(position, Error::Expected(From::from("even number")));
+///         Err(Consumed::Empty(errors))
+///     }
+/// });
+/// let result = even_digit
+///     .parse("8")
+///     .map(|x| x.0);
+/// assert_eq!(result, Ok(8));
+/// # }
+/// ```
+#[inline(always)]
+pub fn lazy_parser<I, O, F, G>(parse: F, add_error: G) -> LazyParser<I, F, G>
+where
+    I: Stream,
+    F: FnMut(I) -> ConsumedResult<O, I>,
+    G: FnMut(&mut ParseError<I>),
+{
+    LazyParser(parse, add_error, PhantomData)
+}
+
 #[derive(Clone)]
 pub struct FnParser<I, F>(F, PhantomData<fn(I) -> I>);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -212,7 +212,10 @@ macro_rules! impl_token_parser {
 ///     integer[I](I) -> i32
 ///         where [I: Stream<Item = char>]
 ///     {
-///         many1(digit()).and_then(|s: String| s.parse())
+///         // The body must be a block body ( `{ <block body> }`) which ends with an expression
+///         // which evaluates to a parser
+///         let digits = many1(digit());
+///         digits.and_then(|s: String| s.parse())
 ///     }
 /// }
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -209,7 +209,7 @@ macro_rules! impl_token_parser {
 /// use combine::{any, choice, many1, Parser, Stream};
 ///
 /// parser!{
-///     integer[I]()(I) -> i32
+///     fn integer[I]()(I) -> i32
 ///         where [I: Stream<Item = char>]
 ///     {
 ///         // The body must be a block body ( `{ <block body> }`) which ends with an expression
@@ -229,7 +229,7 @@ macro_rules! impl_token_parser {
 ///     // Documentation comments works as well
 ///
 ///     /// Parses an integer or a string (any characters)
-///     pub integer_or_string[I]()(I) -> IntOrString
+///     pub fn integer_or_string[I]()(I) -> IntOrString
 ///         where [I: Stream<Item = char>]
 ///     {
 ///         choice!(
@@ -240,7 +240,7 @@ macro_rules! impl_token_parser {
 /// }
 ///
 /// parser!{
-///     pub twice[F, P](f: F)(P::Input) -> (P::Output, P::Output)
+///     pub fn twice[F, P](f: F)(P::Input) -> (P::Output, P::Output)
 ///         where [P: Parser,
 ///                F: FnMut() -> P]
 ///     {
@@ -261,38 +261,38 @@ macro_rules! impl_token_parser {
 macro_rules! parser {
     (
         $(#[$attr:meta])*
-        $name: ident [$($type_params: tt)*]( $($arg: ident :  $arg_type: ty),* )
+        fn $name: ident [$($type_params: tt)*]( $($arg: ident :  $arg_type: ty),* )
             ($input_type: ty) -> $output_type: ty
             { $($parser: tt)* }
     ) => {
         parser!{
             $(#[$attr])*
-            $name [$($type_params)*]( $($arg : $arg_type),* )($input_type) -> $output_type
+            fn $name [$($type_params)*]( $($arg : $arg_type),* )($input_type) -> $output_type
                 where []
             { $($parser)* }
         }
     };
     (
         $(#[$attr:meta])*
-        pub $name: ident [$($type_params: tt)*]( $($arg: ident :  $arg_type: ty),* )
+        pub fn $name: ident [$($type_params: tt)*]( $($arg: ident :  $arg_type: ty),* )
             ($input_type: ty) -> $output_type: ty
             where [$($where_clause: tt)*]
         { $($parser: tt)* }
     ) => {
         combine_parser_impl!{
-            (pub) $name [$($type_params)*]($($arg : $arg_type),*)($input_type) -> $output_type
+            (pub) fn $name [$($type_params)*]($($arg : $arg_type),*)($input_type) -> $output_type
                 where [$($where_clause)*]
             { $($parser)* }
         }
     };
     (
         $(#[$attr:meta])*
-        $name: ident [$($type_params: tt)*]( $($arg: ident :  $arg_type: ty),*) ($input_type: ty) -> $output_type: ty
+        fn $name: ident [$($type_params: tt)*]( $($arg: ident :  $arg_type: ty),*) ($input_type: ty) -> $output_type: ty
             where [$($where_clause: tt)*]
         { $($parser: tt)* }
     ) => {
         combine_parser_impl!{
-            () $name [$($type_params)*]($($arg : $arg_type),*)($input_type) -> $output_type
+            () fn $name [$($type_params)*]($($arg : $arg_type),*)($input_type) -> $output_type
                 where [$($where_clause)*]
             { $($parser)* }
         }
@@ -341,7 +341,7 @@ macro_rules! combine_parser_impl {
     (
         $(#[$attr:meta])*
         ( $($pub_: tt)* )
-        $name: ident [$($type_params: tt)*]( $($arg: ident :  $arg_type: ty),*) ($input_type: ty) -> $output_type: ty
+        fn $name: ident [$($type_params: tt)*]( $($arg: ident :  $arg_type: ty),*) ($input_type: ty) -> $output_type: ty
             where [$($where_clause: tt)*]
         { $($parser: tt)* }
     ) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -260,7 +260,10 @@ macro_rules! impl_token_parser {
 ///     assert!(integer().parse("!").is_err());
 ///
 ///     assert_eq!(integer_or_string().parse("123"), Ok((IntOrString::Int(123), "")));
-///     assert_eq!(integer_or_string().parse("abc"), Ok((IntOrString::String("abc".to_string()), "")));
+///     assert_eq!(
+///         integer_or_string().parse("abc"),
+///         Ok((IntOrString::String("abc".to_string()), ""))
+///     );
 ///     assert_eq!(twice(|| digit()).parse("123"), Ok((('1', '2'), "3")));
 /// }
 /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,7 +197,30 @@ macro_rules! impl_token_parser {
 }
 }
 
-/// Declares a named parser which can easily be reused
+/// Declares a named parser which can easily be reused.
+///
+/// The expression which creates the parser should have no side effects as it may be called
+/// multiple times even during a single parse attempt.
+///
+/// ```
+/// #[macro_use]
+/// extern crate combine;
+/// use combine::char::digit;
+/// use combine::{many1, Parser, Stream};
+///
+/// parser!{
+///     integer[I](I) -> i32
+///         where [I: Stream<Item = char>]
+///     {
+///         many1(digit()).and_then(|s: String| s.parse())
+///     }
+/// }
+///
+/// fn main() {
+///     assert_eq!(integer().parse("123"), Ok((123, "")));
+///     assert!(integer().parse("!").is_err());
+/// }
+/// ```
 #[macro_export]
 macro_rules! parser {
     (

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -261,6 +261,19 @@ macro_rules! impl_token_parser {
 macro_rules! parser {
     (
         $(#[$attr:meta])*
+        pub fn $name: ident [$($type_params: tt)*]( $($arg: ident :  $arg_type: ty),* )
+            ($input_type: ty) -> $output_type: ty
+            { $($parser: tt)* }
+    ) => {
+        parser!{
+            $(#[$attr])*
+            pub fn $name [$($type_params)*]( $($arg : $arg_type),* )($input_type) -> $output_type
+                where []
+            { $($parser)* }
+        }
+    };
+    (
+        $(#[$attr:meta])*
         fn $name: ident [$($type_params: tt)*]( $($arg: ident :  $arg_type: ty),* )
             ($input_type: ty) -> $output_type: ty
             { $($parser: tt)* }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -221,8 +221,11 @@ macro_rules! impl_token_parser {
 ///     Int(i32),
 ///     String(String),
 /// }
+/// // prefix with `pub` to declare a public parser
 /// parser!{
-///     // prefix with `pub` to declare a public parser
+///     // Documentation comments works as well
+///
+///     /// Parses an integer or a string (any characters)
 ///     pub integer_or_string[I](I) -> IntOrString
 ///         where [I: Stream<Item = char>]
 ///     {
@@ -244,26 +247,31 @@ macro_rules! impl_token_parser {
 #[macro_export]
 macro_rules! parser {
     (
+        $(#[$attr:meta])*
         pub $name: ident [$($type_params: tt)*]($input_type: ty) -> $output_type: ty
             { $($parser: tt)* }
     ) => {
         parser!{
+            $(#[$attr])*
             pub $name [$($type_params)*]($input_type) -> $output_type
                 where []
             { $($parser)* }
         }
     };
     (
+        $(#[$attr:meta])*
         $name: ident [$($type_params: tt)*]($input_type: ty) -> $output_type: ty
             { $($parser: tt)* }
     ) => {
         parser!{
+            $(#[$attr])*
             $name [$($type_params)*]($input_type) -> $output_type
                 where []
             { $($parser)* }
         }
     };
     (
+        $(#[$attr:meta])*
         pub $name: ident [$($type_params: tt)*]($input_type: ty) -> $output_type: ty
             where [$($where_clause: tt)*]
         { $($parser: tt)* }
@@ -273,6 +281,8 @@ macro_rules! parser {
                 where [$($where_clause)*]
             { $($parser)* }
         }
+
+        $(#[$attr])*
         #[inline(always)]
         pub fn $name< $($type_params)* >(
             ) -> self::$name::P<$($type_params)*>
@@ -282,6 +292,7 @@ macro_rules! parser {
         }
     };
     (
+        $(#[$attr:meta])*
         $name: ident [$($type_params: tt)*]($input_type: ty) -> $output_type: ty
             where [$($where_clause: tt)*]
         { $($parser: tt)* }
@@ -291,6 +302,8 @@ macro_rules! parser {
                 where [$($where_clause)*]
             { $($parser)* }
         }
+
+        $(#[$attr])*
         #[inline(always)]
         fn $name< $($type_params)* >(
             ) -> self::$name::P<$($type_params)*>

--- a/tests/date.rs
+++ b/tests/date.rs
@@ -36,7 +36,7 @@ fn two_digits_to_int((x, y): (char, char)) -> i32 {
 
 
 parser!{
-    two_digits [I](I) -> i32
+    two_digits[I](I) -> i32
     where
         [I: Stream<Item = char>,]
     {

--- a/tests/date.rs
+++ b/tests/date.rs
@@ -36,7 +36,7 @@ fn two_digits_to_int((x, y): (char, char)) -> i32 {
 
 
 parser!{
-    two_digits[I](I) -> i32
+    two_digits [I](I) -> i32
     where
         [I: Stream<Item = char>,]
     {
@@ -126,7 +126,7 @@ parser!{
 /// Parses a date time according to ISO8601
 /// 2015-08-02T18:54:42+02
 parser!{
-    date_time[I](I) -> DateTime
+    date_time [I](I) -> DateTime
     where
         [I: Stream<Item = char>,]
     {

--- a/tests/date.rs
+++ b/tests/date.rs
@@ -36,7 +36,7 @@ fn two_digits_to_int((x, y): (char, char)) -> i32 {
 
 
 parser!{
-    two[F, P](d: F)(P::Input) -> i32
+    fn two[F, P](d: F)(P::Input) -> i32
     where
         [P::Input: Stream<Item = char>,
          P: Parser<Output = char>,
@@ -53,7 +53,7 @@ parser!{
 /// -01
 /// Z
 parser!{
-    time_zone[I]()(I) -> i32
+    fn time_zone[I]()(I) -> i32
     where
         [I: Stream<Item = char>,]
     {
@@ -78,7 +78,7 @@ parser!{
 /// Parses a date
 /// 2010-01-30
 parser!{
-    date[I]()(I) -> Date
+    fn date[I]()(I) -> Date
     where
         [I: Stream<Item = char>,]
     {
@@ -102,7 +102,7 @@ parser!{
 /// Parses a time
 /// 12:30:02
 parser!{
-    time[I]()(I) -> Time
+    fn time[I]()(I) -> Time
     where
         [I: Stream<Item = char>,]
     {
@@ -128,7 +128,7 @@ parser!{
 /// Parses a date time according to ISO8601
 /// 2015-08-02T18:54:42+02
 parser!{
-    date_time[I]()(I) -> DateTime
+    fn date_time[I]()(I) -> DateTime
     where
         [I: Stream<Item = char>,]
     {

--- a/tests/ini.rs
+++ b/tests/ini.rs
@@ -15,7 +15,7 @@ pub struct Ini {
 }
 
 parser!{
-    property[I](I) -> (String, String)
+    property[I]()(I) -> (String, String)
         where [I: Stream<Item = char>]
     {
         (
@@ -27,7 +27,7 @@ parser!{
     }
 }
 parser!{
-    whitespace[I](I) -> ()
+    whitespace[I]()(I) -> ()
     where
         [I: Stream<Item = char>,]
     {
@@ -39,7 +39,7 @@ parser!{
 }
 
 parser!{
-    properties[I](I) -> HashMap<String, String>
+    properties[I]()(I) -> HashMap<String, String>
     where
         [I: Stream<Item = char>,]
     {
@@ -49,7 +49,7 @@ parser!{
 }
 
 parser!{
-    section[I](I) -> (String, HashMap<String, String>)
+    section[I]()(I) -> (String, HashMap<String, String>)
     where
         [I: Stream<Item = char>,]
     {
@@ -63,7 +63,7 @@ parser!{
 }
 
 parser!{
-    ini[I](I) -> Ini
+    ini[I]()(I) -> Ini
     where
         [I: Stream<Item = char>,]
     {

--- a/tests/ini.rs
+++ b/tests/ini.rs
@@ -15,7 +15,7 @@ pub struct Ini {
 }
 
 parser!{
-    property[I]()(I) -> (String, String)
+    fn property[I]()(I) -> (String, String)
         where [I: Stream<Item = char>]
     {
         (
@@ -27,7 +27,7 @@ parser!{
     }
 }
 parser!{
-    whitespace[I]()(I) -> ()
+    fn whitespace[I]()(I) -> ()
     where
         [I: Stream<Item = char>,]
     {
@@ -39,7 +39,7 @@ parser!{
 }
 
 parser!{
-    properties[I]()(I) -> HashMap<String, String>
+    fn properties[I]()(I) -> HashMap<String, String>
     where
         [I: Stream<Item = char>,]
     {
@@ -49,7 +49,7 @@ parser!{
 }
 
 parser!{
-    section[I]()(I) -> (String, HashMap<String, String>)
+    fn section[I]()(I) -> (String, HashMap<String, String>)
     where
         [I: Stream<Item = char>,]
     {
@@ -63,7 +63,7 @@ parser!{
 }
 
 parser!{
-    ini[I]()(I) -> Ini
+    fn ini[I]()(I) -> Ini
     where
         [I: Stream<Item = char>,]
     {

--- a/tests/ini.rs
+++ b/tests/ini.rs
@@ -15,7 +15,9 @@ pub struct Ini {
 }
 
 parser!{
-    property[I: Stream<Item = char>](I) -> (String, String) {
+    property[I](I) -> (String, String)
+        where [I: Stream<Item = char>]
+    {
         (
             many1(satisfy(|c| c != '=' && c != '[' && c != ';')),
             token('='),

--- a/tests/ini.rs
+++ b/tests/ini.rs
@@ -1,4 +1,5 @@
 //! Parser example for INI files.
+#[macro_use]
 extern crate combine;
 
 use std::collections::HashMap;
@@ -13,65 +14,68 @@ pub struct Ini {
     pub sections: HashMap<String, HashMap<String, String>>,
 }
 
-fn property<I>(input: I) -> ParseResult<(String, String), I>
-where
-    I: Stream<Item = char>,
-{
-    (
-        many1(satisfy(|c| c != '=' && c != '[' && c != ';')),
-        token('='),
-        many1(satisfy(|c| c != '\n' && c != ';')),
-    ).map(|(key, _, value)| (key, value))
-        .message("while parsing property")
-        .parse_stream(input)
+parser!{
+    property[I: Stream<Item = char>](I) -> (String, String) {
+        (
+            many1(satisfy(|c| c != '=' && c != '[' && c != ';')),
+            token('='),
+            many1(satisfy(|c| c != '\n' && c != ';')),
+        ).map(|(key, _, value)| (key, value))
+            .message("while parsing property")
+    }
+}
+parser!{
+    whitespace[I](I) -> ()
+    where
+        [I: Stream<Item = char>,]
+    {
+        let comment = (token(';'), skip_many(satisfy(|c| c != '\n'))).map(|_| ());
+        // Wrap the `spaces().or(comment)` in `skip_many` so that it skips alternating whitespace and
+        // comments
+        skip_many(skip_many1(space()).or(comment))
+    }
 }
 
-fn whitespace<I>(input: I) -> ParseResult<(), I>
-where
-    I: Stream<Item = char>,
-{
-    let comment = (token(';'), skip_many(satisfy(|c| c != '\n'))).map(|_| ());
-    // Wrap the `spaces().or(comment)` in `skip_many` so that it skips alternating whitespace and
-    // comments
-    skip_many(skip_many1(space()).or(comment)).parse_stream(input)
+parser!{
+    properties[I](I) -> HashMap<String, String>
+    where
+        [I: Stream<Item = char>,]
+    {
+        // After each property we skip any whitespace that followed it
+        many(property().skip(whitespace()))
+    }
 }
 
-fn properties<I>(input: I) -> ParseResult<HashMap<String, String>, I>
-where
-    I: Stream<Item = char>,
-{
-    // After each property we skip any whitespace that followed it
-    many(parser(property).skip(parser(whitespace))).parse_stream(input)
+parser!{
+    section[I](I) -> (String, HashMap<String, String>)
+    where
+        [I: Stream<Item = char>,]
+    {
+        (
+            between(token('['), token(']'), many(satisfy(|c| c != ']'))),
+            whitespace(),
+            properties(),
+        ).map(|(name, _, properties)| (name, properties))
+            .message("while parsing section")
+    }
 }
 
-fn section<I>(input: I) -> ParseResult<(String, HashMap<String, String>), I>
-where
-    I: Stream<Item = char>,
-{
-    (
-        between(token('['), token(']'), many(satisfy(|c| c != ']'))),
-        parser(whitespace),
-        parser(properties),
-    ).map(|(name, _, properties)| (name, properties))
-        .message("while parsing section")
-        .parse_stream(input)
-}
-
-fn ini<I>(input: I) -> ParseResult<Ini, I>
-where
-    I: Stream<Item = char>,
-{
-    (
-        parser(whitespace),
-        parser(properties),
-        many(parser(section)),
-    ).map(|(_, global, sections)| {
-            Ini {
-                global: global,
-                sections: sections,
-            }
-        })
-        .parse_stream(input)
+parser!{
+    ini[I](I) -> Ini
+    where
+        [I: Stream<Item = char>,]
+    {
+        (
+            whitespace(),
+            properties(),
+            many(section()),
+        ).map(|(_, global, sections)| {
+                Ini {
+                    global: global,
+                    sections: sections,
+                }
+            })
+    }
 }
 
 #[test]
@@ -97,14 +101,14 @@ type=LL(1)
     section.insert(String::from("type"), String::from("LL(1)"));
     expected.sections.insert(String::from("section"), section);
 
-    let result = parser(ini).parse(text).map(|t| t.0);
+    let result = ini().parse(text).map(|t| t.0);
     assert_eq!(result, Ok(expected));
 }
 
 #[test]
 fn ini_error() {
     let text = "[error";
-    let result = parser(ini).parse(State::new(text)).map(|t| t.0);
+    let result = ini().parse(State::new(text)).map(|t| t.0);
     assert_eq!(
         result,
         Err(ParseError {


### PR DESCRIPTION
While it has a slightly weird syntax to work around some ambiguity problems this should provide a defacto way to implement reusable parsers.

Fixes #70

