### PR TITLE
feat: Accept arbitrary blocks in the parser! macro

### DIFF
--- a/src/easy.rs
+++ b/src/easy.rs
@@ -464,11 +464,8 @@ impl<T, R> Error<T, R> {
 }
 
 /// Alias over `ParseError` for `StreamOnce` types
-pub type StreamErrors<S> = Errors<
-    <S as StreamOnce>::Position,
-    <S as StreamOnce>::Item,
-    <S as StreamOnce>::Range,
->;
+pub type StreamErrors<S> =
+    Errors<<S as StreamOnce>::Position, <S as StreamOnce>::Item, <S as StreamOnce>::Range>;
 
 /// Struct which hold information about an error that occured at a specific position.
 /// Can hold multiple instances of `Error` if more that one error occured in the same position.

--- a/tests/parser_macro.rs
+++ b/tests/parser_macro.rs
@@ -5,7 +5,14 @@ parser!{
     fn test[I]()(I) -> ()
         where [I: ::combine::Stream<Item = char>]
     {
-        ::combine::combinator::value(())
+        use combine::combinator::value;
+        let _ = ();
+        fn _test() { }
+        match Some(1) {
+            Some(_) => (),
+            None => (),
+        }
+        value(())
     }
 }
 


### PR DESCRIPTION
This allows items to be put into `parser!` and should make error
messages clearer.

BREAKING CHANGE

`parser!` no longer works when the resulting parser contains borrows to
stack allocated values. This was necessary to support the improvements
and is also consistent with how returning `impl Parser` works.