### PR TITLE
Fix a few typos in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ https://github.com/Marwes/combine/issues/73 contains discussion and links to com
 ### Miscellaneous
 
 * Template language https://github.com/tailhook/trimmer
-* Code excercises https://github.com/dgel/adventOfCode2017
+* Code exercises https://github.com/dgel/adventOfCode2017
 * Programming language https://github.com/MaikKlein/spire-lang
 * Query parser (+ more) https://github.com/mozilla/mentat
 * Query parser https://github.com/tantivy-search/tantivy

--- a/src/error.rs
+++ b/src/error.rs
@@ -195,7 +195,7 @@ impl<T> Consumed<T> {
     }
 }
 
-/// A type alias over the specific `Result` type used by parsers to indicate wether they were
+/// A type alias over the specific `Result` type used by parsers to indicate whether they were
 /// successful or not.
 /// `O` is the type that is output on success.
 /// `I` is the specific stream type used in the parser.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,9 @@
 //! This crate contains parser combinators, roughly based on the Haskell libraries
 //! [parsec](http://hackage.haskell.org/package/parsec) and
-//! [attparsec](https://hackage.haskell.org/package/attoparsec).
+//! [attoparsec](https://hackage.haskell.org/package/attoparsec).
 //!
 //! A parser in this library can be described as a function which takes some input and if it
-//! is succesful, returns a value together with the remaining input.
+//! is successful, returns a value together with the remaining input.
 //! A parser combinator is a function which takes one or more parsers and returns a new parser.
 //! For instance the [`many`] parser can be used to convert a parser for single digits into one that
 //! parses multiple digits. By modeling parsers in this way it becomes easy to compose complex
@@ -249,7 +249,7 @@ macro_rules! impl_token_parser {
 /// use combine::error::ParseError;
 ///
 /// parser!{
-///     /// `[I]` represents a normal type parametera and lifetime declaration for the function
+///     /// `[I]` represents a normal type parameters and lifetime declaration for the function
 ///     /// It gets expanded to `<I>`
 ///     fn integer[I]()(I) -> i32
 ///     where [

--- a/src/parser/item.rs
+++ b/src/parser/item.rs
@@ -292,7 +292,7 @@ where
 
 /// Parses multiple tokens.
 ///
-/// Consumes items from the input and comparse them to the values from `tokens` using the
+/// Consumes items from the input and compares them to the values from `tokens` using the
 /// comparison function `cmp`. Succeeds if all the items from `tokens` are matched in the input
 /// stream and fails otherwise with `expected` used as part of the error.
 ///

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -739,7 +739,7 @@ pub trait Parser {
     /// assert_eq!(result, Ok((1234, "")));
     /// let result = parser.easy_parse(State::new("999999999999999999999999"));
     /// assert!(result.is_err());
-    /// // Errors are report as if they occured at the start of the parse
+    /// // Errors are report as if they occurred at the start of the parse
     /// assert_eq!(result.unwrap_err().position, SourcePosition { line: 1, column: 1 });
     /// # }
     /// ```

--- a/src/parser/range.rs
+++ b/src/parser/range.rs
@@ -192,7 +192,7 @@ where
     RecognizeWithValue(parser)
 }
 
-/// Zero-copy parser which reads a range of length `i.len()` and succeds if `i` is equal to that
+/// Zero-copy parser which reads a range of length `i.len()` and succeeds if `i` is equal to that
 /// range.
 ///
 /// ```

--- a/src/stream/buffered.rs
+++ b/src/stream/buffered.rs
@@ -4,7 +4,7 @@ use error::StreamError;
 use stream::{Positioned, Resetable, StreamErrorFor, StreamOnce};
 
 /// `Stream` which buffers items from an instance of `StreamOnce` into a ring buffer.
-/// Instancs of `StreamOnce` which is not able to implement `Resetable` (such as `ReadStream`) may
+/// Instances of `StreamOnce` which is not able to implement `Resetable` (such as `ReadStream`) may
 /// use this as a way to implement `Resetable` and become a full `Stream` instance.
 ///
 /// The drawback is that the buffer only stores a limited number of items which limits how many
@@ -18,7 +18,7 @@ use stream::{Positioned, Resetable, StreamErrorFor, StreamOnce};
 /// ```ignore
 /// // DO
 /// BufferedStream::new(easy::Stream(..), ..)
-/// // DONT
+/// // DON'T
 /// easy::Stream(BufferedStream::new(.., ..))
 /// parser.easy_parse(BufferedStream::new(..));
 /// ```
@@ -75,7 +75,7 @@ where
         } else if self.offset < self.buffer_offset - self.buffer.len() {
             self.buffer
                 .front()
-                .expect("Atleast 1 element in the buffer")
+                .expect("At least 1 element in the buffer")
                 .1
                 .clone()
         } else {

--- a/src/stream/easy.rs
+++ b/src/stream/easy.rs
@@ -550,8 +550,8 @@ impl<T, R> Error<T, R> {
 pub type ParseError<S> =
     Errors<<S as StreamOnce>::Item, <S as StreamOnce>::Range, <S as StreamOnce>::Position>;
 
-/// Struct which hold information about an error that occured at a specific position.
-/// Can hold multiple instances of `Error` if more that one error occured in the same position.
+/// Struct which hold information about an error that occurred at a specific position.
+/// Can hold multiple instances of `Error` if more that one error occurred in the same position.
 #[derive(Debug, PartialEq)]
 pub struct Errors<I, R, P> {
     /// The position where the error occurred
@@ -605,7 +605,7 @@ impl<I, R, P> Errors<I, R, P> {
         }
     }
 
-    /// Remvoes all `Expected` errors in `self` and adds `info` instead.
+    /// Removes all `Expected` errors in `self` and adds `info` instead.
     pub fn set_expected(&mut self, info: Info<I, R>) {
         // Remove all other expected messages
         self.errors.retain(|e| match *e {


### PR DESCRIPTION
This is a great library and I am really excited about the 3.0 release! There are a few typos in the docs, however. These are the ones I caught by running `aspell` on the `.rs` files and the `README`.