### PR TITLE
Support Unicode characters in uncons_range for strs

### DIFF
--- a/src/parser/range.rs
+++ b/src/parser/range.rs
@@ -437,7 +437,10 @@ where
                     input.reset(look_ahead_input.clone());
                     
                     // See if we can advance anyway
-                    if let Err(_) = input.uncons() {
+                    if input.uncons().is_err() {
+                        // Reset the stream
+                        input.reset(before);
+
                         // Return the original error if uncons failed
                         return wrap_stream_error(input, first_error);
                     } else {

--- a/src/parser/range.rs
+++ b/src/parser/range.rs
@@ -488,4 +488,10 @@ mod tests {
         let result = parser.parse("hell\u{00EE} world");
         assert!(result.is_err());
     }
+
+    #[test]
+    fn take_until_range_unicode() {
+        let result = take_until_range("🦀").parse("Ferris the friendly rustacean 🦀 and his snake friend 🐍");
+        assert_eq!(result, Ok(("Ferris the friendly rustacean 🦀", " and his snake friend 🐍")));
+    }
 }

--- a/tests/async.rs
+++ b/tests/async.rs
@@ -28,7 +28,7 @@ use combine::combinator::{
 };
 use combine::parser::char::{char, digit, letter};
 use combine::parser::item::item;
-use combine::parser::range::{range, recognize_with_value, take_while, take_while1};
+use combine::parser::range::{range, recognize_with_value, take_while, take_while1, take_until_range};
 use combine::parser::repeat;
 use combine::stream::{easy, RangeStream};
 use combine::{any, count_min_max, many1, skip_many, Parser};
@@ -392,6 +392,19 @@ quickcheck! {
         );
 
         assert_eq!(counter.get(), 3);
+    }
+
+    fn take_until_range_consumed(seq: PartialWithErrors<GenWouldBlock>) -> () {
+        impl_decoder!{ TestParser, String,
+            take_until_range("::").map(String::from).skip((item(':'), item(':')))
+        }
+
+        let input = "123::456::789::";
+
+        let result = run_decoder(input, seq, TestParser(Default::default()));
+
+        assert!(result.as_ref().is_ok(), "{}", result.unwrap_err());
+        assert_eq!(result.unwrap(), ["123", "456", "789"]);
     }
 }
 #[test]


### PR DESCRIPTION
This modifies `uncons_range` to uncons a number of chars instead of a number of
bytes for `str`s.

The reasons for this change is that `uncons_range` was was causing `UnexpectedParse` errors with functions like `take_until_range` when Unicode characters were present in the string being parsed.

I worry a bit about the performance impact for calls to `uncons_range` with large `size` arguments, but I can't think of a better way to fix the issue, besides maybe a feature flag to opt in/out of unicode support.