### PR TITLE
fix: Propagate the ParseMode in range::recognize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+<a name="3.3.5"></a>
+### 3.3.5 (2018-06-30)
+
+
+#### Bug Fixes
+
+*   Propagate the ParseMode in range::recognize ([c330a737](https://github.com/Marwes/combine/commit/c330a73746f6adfa22c6b13b15d796d48f589614))
+
+
+
 <a name="3.3.4"></a>
 ### 3.3.4 (2018-06-30)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <a name="3.3.4"></a>
-### 3.3.1 (2018-06-30)
+### 3.3.4 (2018-06-30)
 
 * fix: Forward the partial mode through the parser! macro correctly
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "combine"
-version = "3.3.5"
+version = "3.3.6-alpha.0"
 authors = ["Markus Westerlind <marwes91@gmail.com>"]
 
 description = "Fast parser combinators on arbitrary streams with zero-copy support."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "combine"
-version = "3.3.5-alpha.0"
+version = "3.3.5"
 authors = ["Markus Westerlind <marwes91@gmail.com>"]
 
 description = "Fast parser combinators on arbitrary streams with zero-copy support."

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,8 @@
+VERSION=$1
+if [ -z "$VERSION"]
+then
+    echo "Expected patch, minor or major"
+    exit 1
+fi
+
+clog --$VERSION && git add CHANGELOG.md && git commit -m "Updated changelog" && cargo release $VERSION

--- a/release.toml
+++ b/release.toml
@@ -1,1 +1,1 @@
-pre-release-hool = ["clog", "-F"]
+pre-release-hook = ["clog", "-F"]

--- a/release.toml
+++ b/release.toml
@@ -1,1 +1,0 @@
-pre-release-hook = ["clog", "-F"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -231,6 +231,16 @@ macro_rules! impl_token_parser {
         }
 
         #[inline]
+        fn parse_first(
+            &mut self,
+            input: &mut Self::Input,
+            state: &mut Self::PartialState,
+        ) -> ConsumedResult<Self::Output, Self::Input>
+        {
+            self.0.parse_first(input, state)
+        }
+
+        #[inline]
         fn parse_partial(
             &mut self,
             input: &mut Self::Input,
@@ -555,6 +565,7 @@ macro_rules! combine_parse_partial {
         $parser.parse_mode($mode, $input, state)
     }};
     (($ignored:ty) $mode:ident $input:ident $state:ident $parser:block) => {
+
         $parser.parse_mode($mode, $input, $state)
     };
 }

--- a/src/parser/combinator.rs
+++ b/src/parser/combinator.rs
@@ -636,12 +636,16 @@ where
         self.0.parse_lazy(input)
     }
 
+    parse_mode!();
     #[inline]
-    fn parse_partial(
+    fn parse_mode<M>(
         &mut self,
+        mode: M,
         input: &mut Self::Input,
         state: &mut Self::PartialState,
-    ) -> ConsumedResult<Self::Output, Self::Input> {
+    ) -> ConsumedResult<Self::Output, Self::Input>
+    where M: ParseMode
+    {
         let mut new_child_state;
         let result = {
             let child_state = if let None = state.0 {
@@ -652,7 +656,7 @@ where
                 state.0.as_mut().unwrap().downcast_mut().unwrap()
             };
 
-            self.0.parse_partial(input, child_state)
+            self.0.parse_mode(mode, input, child_state)
         };
 
         if let ConsumedErr(_) = result {
@@ -730,11 +734,14 @@ where
     }
 
     #[inline]
-    fn parse_partial(
+    fn parse_mode<M>(
         &mut self,
+        mode: M,
         input: &mut Self::Input,
         state: &mut Self::PartialState,
-    ) -> ConsumedResult<Self::Output, Self::Input> {
+    ) -> ConsumedResult<Self::Output, Self::Input>
+    where M: ParseMode
+    {
         let mut new_child_state;
         let result = {
             let child_state = if let None = state.0 {
@@ -745,7 +752,7 @@ where
                 state.0.as_mut().unwrap().downcast_mut().unwrap()
             };
 
-            self.0.parse_partial(input, child_state)
+            self.0.parse_mode(mode, input, child_state)
         };
 
         if let ConsumedErr(_) = result {

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -5,7 +5,7 @@ use combine::parser::choice::{choice, optional};
 use combine::parser::combinator::{no_partial, not_followed_by, try};
 use combine::parser::error::unexpected;
 use combine::parser::item::{any, eof, token, value, Token};
-use combine::parser::range::range;
+use combine::parser::range::{self, range};
 use combine::parser::repeat::{count_min_max, sep_by, sep_end_by1, skip_until, take_until};
 use combine::Parser;
 
@@ -397,6 +397,14 @@ mod tests_std {
         assert_eq!(
             skip_until(try((char('a'), char('b')))).parse("aaab"),
             Ok(((), "ab"))
+        );
+    }
+
+    #[test]
+    fn recognize_parser_issue_168() {
+        assert_eq!(
+            range::recognize(skip_until(try((char('a'), char('b'))))).parse("aaab"),
+            Ok(("aa", "ab"))
         );
     }
 }


### PR DESCRIPTION
I checked all other definitions of `parse_partial` as well and all other seem fine (does not need to be parse_mode instead) as they do not invoke another parser recursively

cc #168