### PR TITLE
doc: Restore the doc link to version 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # combine
 [![Build Status](https://travis-ci.org/Marwes/combine.svg?branch=master)](https://travis-ci.org/Marwes/combine)
-[![Docs v3](https://docs.rs/combine/badge.svg?version=^3)](https://docs.rs/combine/^3)
+[![Docs v2](https://docs.rs/combine/badge.svg?version=^2)](https://docs.rs/combine/^2)
 [![Docs](https://docs.rs/combine/badge.svg)](https://docs.rs/combine)
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/Marwes/combine?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 


### PR DESCRIPTION
Version 3 already has a link through other link that goes to the most recent version