### PR TITLE
Refactors try into attempt

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,10 +202,10 @@ pub use stream::{Positioned, RangeStream, RangeStreamOnce, Stream, StreamOnce};
 
 #[doc(inline)]
 pub use combinator::{
-    any, between, chainl1, chainr1, count, count_min_max, env_parser, eof, look_ahead, many, many1,
-    none_of, not_followed_by, one_of, optional, parser, position, satisfy, satisfy_map, sep_by,
-    sep_by1, sep_end_by, sep_end_by1, skip_count, skip_count_min_max, skip_many, skip_many1, token,
-    tokens, try, unexpected, unexpected_any, value,
+    any, attempt, between, chainl1, chainr1, count, count_min_max, env_parser, eof, look_ahead,
+    many, many1, none_of, not_followed_by, one_of, optional, parser, position, satisfy,
+    satisfy_map, sep_by, sep_by1, sep_end_by, sep_end_by1, skip_count, skip_count_min_max,
+    skip_many, skip_many1, token, tokens, try, unexpected, unexpected_any, value,
 };
 #[doc(inline)]
 pub use parser::choice::choice;
@@ -831,6 +831,17 @@ mod tests {
         }
         let mut p = chainl1(string("abc"), char(',').map(|_| first));
         assert!(p.parse("abc,ab").is_err());
+    }
+
+    #[test]
+    fn attempt_try() {
+        // `attempt` is an alias for `try`. This is a small smoke test for
+        // `attempt`, since the main functionality is tested with `try`
+        let mut parser = choice((
+            attempt((string("abc"), string("def"))),
+            attempt((string("abc"), string("ghi"))),
+        ));
+        assert_eq!(parser.parse("abcghi"), Ok((("abc", "ghi"), "")));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 //! # Overview
 //!
 //! `combine` limits itself to creating [LL(1) parsers](https://en.wikipedia.org/wiki/LL_parser)
-//! (it is possible to opt-in to LL(k) parsing using the [`try`] combinator) which makes the
+//! (it is possible to opt-in to LL(k) parsing using the [`attempt`] combinator) which makes the
 //! parsers easy to reason about in both function and performance while sacrificing
 //! some generality. In addition to you being able to reason better about the parsers you
 //! construct `combine` the library also takes the knowledge of being an LL parser and uses it to
@@ -177,7 +177,7 @@
 //! [`byte`]: parser/byte/index.html
 //! [`range`]: parser/range/index.html
 //! [`many`]: parser/repeat/fn.many.html
-//! [`try`]: parser/combinator/fn.try.html
+//! [`attempt`]: parser/combinator/fn.attempt.html
 //! [`satisfy`]: parser/item/fn.satisfy.html
 //! [`or`]: parser/trait.Parser.html#method.or
 //! [`Stream`]: stream/trait.Stream.html
@@ -201,6 +201,7 @@ pub use parser::Parser;
 pub use stream::{Positioned, RangeStream, RangeStreamOnce, Stream, StreamOnce};
 
 #[doc(inline)]
+#[allow(deprecated)] // Needed to re-export `try`
 pub use combinator::{
     any, attempt, between, chainl1, chainr1, count, count_min_max, env_parser, eof, look_ahead,
     many, many1, none_of, not_followed_by, one_of, optional, parser, position, satisfy,
@@ -834,12 +835,13 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn attempt_try() {
         // `attempt` is an alias for `try`. This is a small smoke test for
-        // `attempt`, since the main functionality is tested with `try`
+        // `try`, since the main functionality is tested with `attempt`
         let mut parser = choice((
-            attempt((string("abc"), string("def"))),
-            attempt((string("abc"), string("ghi"))),
+            try((string("abc"), string("def"))),
+            try((string("abc"), string("ghi"))),
         ));
         assert_eq!(parser.parse("abcghi"), Ok((("abc", "ghi"), "")));
     }
@@ -847,12 +849,12 @@ mod tests {
     #[test]
     fn choice_strings() {
         let mut fruits = [
-            try(string("Apple")),
-            try(string("Banana")),
-            try(string("Cherry")),
-            try(string("Date")),
-            try(string("Fig")),
-            try(string("Grape")),
+            attempt(string("Apple")),
+            attempt(string("Banana")),
+            attempt(string("Cherry")),
+            attempt(string("Date")),
+            attempt(string("Fig")),
+            attempt(string("Grape")),
         ];
         let mut parser = choice(&mut fruits);
         assert_eq!(parser.parse("Apple"), Ok(("Apple", "")));

--- a/src/parser/choice.rs
+++ b/src/parser/choice.rs
@@ -537,8 +537,8 @@ where
 /// // Fails as the parser for "two" consumes the first 't' before failing
 /// assert!(parser2.parse("three").is_err());
 ///
-/// // Use 'try' to make failing parsers always act as if they have not consumed any input
-/// let mut parser3 = choice([try(string("one")), try(string("two")), try(string("three"))]);
+/// // Use 'attempt' to make failing parsers always act as if they have not consumed any input
+/// let mut parser3 = choice([attempt(string("one")), attempt(string("two")), attempt(string("three"))]);
 /// assert_eq!(parser3.parse("three"), Ok(("three", "")));
 /// # }
 /// ```
@@ -610,8 +610,8 @@ where
 /// // Fails as the parser for "two" consumes the first 't' before failing
 /// assert!(parser2.parse("three").is_err());
 ///
-/// // Use 'try' to make failing parsers always act as if they have not consumed any input
-/// let mut parser3 = or(try(string("two")), try(string("three")));
+/// // Use 'attempt' to make failing parsers always act as if they have not consumed any input
+/// let mut parser3 = or(attempt(string("two")), attempt(string("three")));
 /// assert_eq!(parser3.parse("three"), Ok(("three", "")));
 /// # }
 /// ```

--- a/src/parser/combinator.rs
+++ b/src/parser/combinator.rs
@@ -117,8 +117,36 @@ where
 /// assert!(result.is_err());
 /// # }
 /// ```
+///
+/// Note: if you're on the 2018 edition, you'll need to either use `r#try`, or [`attempt`](fn.attempt.html)
 #[inline(always)]
 pub fn try<P>(p: P) -> Try<P>
+where
+    P: Parser,
+{
+    Try(p)
+}
+
+/// `attempt(p)` behaves as `p` except it acts as if the parser hadn't consumed any input if `p` fails
+/// after consuming input. (alias for [`try`](fn.try.html))
+///
+/// ```
+/// # extern crate combine;
+/// # use combine::*;
+/// # use combine::parser::char::string;
+/// # fn main() {
+/// let mut p = attempt(string("let"))
+///     .or(string("lex"));
+/// let result = p.parse("lex").map(|x| x.0);
+/// assert_eq!(result, Ok("lex"));
+/// let result = p.parse("aet").map(|x| x.0);
+/// assert!(result.is_err());
+/// # }
+/// ```
+///
+/// `attempt` is an alias for [`try`](fn.try.html). It was added because [`try`](fn.try.html) is now a keyword in Rust 2018.
+#[inline(always)]
+pub fn attempt<P>(p: P) -> Try<P>
 where
     P: Parser,
 {

--- a/src/parser/combinator.rs
+++ b/src/parser/combinator.rs
@@ -119,6 +119,10 @@ where
 /// ```
 ///
 /// Note: if you're on the 2018 edition, you'll need to either use `r#try`, or [`attempt`](fn.attempt.html)
+#[deprecated(
+    since = "3.5",
+    note = "try is a reserved keyword in Rust 2018. Use attempt instead."
+)]
 #[inline(always)]
 pub fn try<P>(p: P) -> Try<P>
 where

--- a/src/parser/combinator.rs
+++ b/src/parser/combinator.rs
@@ -41,11 +41,15 @@ where [
     P::Output: Into<Info<<P::Input as StreamOnce>::Item, <P::Input as StreamOnce>::Range>>,
 ]
 {
-    try(try(parser).then(unexpected)
+    attempt(attempt(parser).then(unexpected)
         .or(value(())))
 }
 }
 
+/**
+ * TODO :: Rename `Try` to `Attempt`
+ * Because this is public, it's name cannot be changed without also making a breaking change.
+ */
 #[derive(Copy, Clone)]
 pub struct Try<P>(P);
 impl<I, O, P> Parser for Try<P>

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -524,8 +524,8 @@ pub trait Parser {
     /// // Fails as the parser for "two" consumes the first 't' before failing
     /// assert!(parser2.parse("three").is_err());
     ///
-    /// // Use 'try' to make failing parsers always act as if they have not consumed any input
-    /// let mut parser3 = try(string("two")).or(try(string("three")));
+    /// // Use 'attempt' to make failing parsers always act as if they have not consumed any input
+    /// let mut parser3 = attempt(string("two")).or(attempt(string("three")));
     /// assert_eq!(parser3.parse("three"), Ok(("three", "")));
     /// # }
     /// ```

--- a/src/parser/range.rs
+++ b/src/parser/range.rs
@@ -200,7 +200,7 @@ where
 /// # fn main() {
 /// let mut parser = recognize_with_value((
 ///     skip_many1(digit()),
-///     optional((try(char('.')), skip_many1(digit()))),
+///     optional((attempt(char('.')), skip_many1(digit()))),
 /// ).map(|(_, opt)| opt.is_some()));
 ///
 /// assert_eq!(parser.parse("1234!"), Ok((("1234", false), "!")));

--- a/src/parser/repeat.rs
+++ b/src/parser/repeat.rs
@@ -1184,14 +1184,14 @@ where
 }
 
 /// Takes input until `end` is encountered or `end` indicates that it has consumed input before
-/// failing (`try` can be used to make it look like it has not consumed any input)
+/// failing (`attempt` can be used to make it look like it has not consumed any input)
 ///
 /// ```
 /// # extern crate combine;
 /// # use combine::*;
 /// # use combine::parser::char;
 /// # use combine::parser::byte;
-/// # use combine::parser::combinator::try;
+/// # use combine::parser::combinator::attempt;
 /// # use combine::parser::repeat::take_until;
 /// # fn main() {
 ///     let mut char_parser = take_until(char::digit());
@@ -1201,8 +1201,8 @@ where
 ///     assert_eq!(byte_parser.parse(&b"123TAG"[..]), Ok((b"123".to_vec(), &b"TAG"[..])));
 ///     assert!(byte_parser.parse(&b"123TATAG"[..]).is_err());
 ///
-///     // `try` must be used if the `end` should be consume input before failing
-///     let mut byte_parser = take_until(try(byte::bytes(&b"TAG"[..])));
+///     // `attempt` must be used if the `end` should be consume input before failing
+///     let mut byte_parser = take_until(attempt(byte::bytes(&b"TAG"[..])));
 ///     assert_eq!(byte_parser.parse(&b"123TATAG"[..]), Ok((b"123TA".to_vec(), &b"TAG"[..])));
 /// }
 /// ```
@@ -1222,14 +1222,14 @@ parser!{
     #[derive(Copy, Clone)]
     pub struct SkipUntil;
     /// Skips input until `end` is encountered or `end` indicates that it has consumed input before
-    /// failing (`try` can be used to make it look like it has not consumed any input)
+    /// failing (`attempt` can be used to make it look like it has not consumed any input)
     ///
     /// ```
     /// # extern crate combine;
     /// # use combine::*;
     /// # use combine::parser::char;
     /// # use combine::parser::byte;
-    /// # use combine::parser::combinator::try;
+    /// # use combine::parser::combinator::attempt;
     /// # use combine::parser::repeat::skip_until;
     /// # fn main() {
     ///     let mut char_parser = skip_until(char::digit());
@@ -1239,8 +1239,8 @@ parser!{
     ///     assert_eq!(byte_parser.parse(&b"123TAG"[..]), Ok(((), &b"TAG"[..])));
     ///     assert!(byte_parser.parse(&b"123TATAG"[..]).is_err());
     ///
-    ///     // `try` must be used if the `end` should be consume input before failing
-    ///     let mut byte_parser = skip_until(try(byte::bytes(&b"TAG"[..])));
+    ///     // `attempt` must be used if the `end` should be consume input before failing
+    ///     let mut byte_parser = skip_until(attempt(byte::bytes(&b"TAG"[..])));
     ///     assert_eq!(byte_parser.parse(&b"123TATAG"[..]), Ok(((), &b"TAG"[..])));
     /// }
     /// ```

--- a/tests/buffered_stream.rs
+++ b/tests/buffered_stream.rs
@@ -5,7 +5,7 @@ use combine::stream::buffered::BufferedStream;
 use combine::stream::easy::{self, Error};
 use combine::stream::state::State;
 use combine::stream::IteratorStream;
-use combine::{choice, many, many1, sep_by, try, Parser, Positioned};
+use combine::{attempt, choice, many, many1, sep_by, Parser, Positioned};
 
 #[test]
 fn shared_stream_buffer() {
@@ -32,9 +32,9 @@ fn shared_stream_backtrack() {
     let stream = BufferedStream::new(State::new(IteratorStream::new(&mut iter)), 2);
 
     let value: &mut Parser<Input = _, Output = _, PartialState = _> = &mut choice([
-        try(string("apple")),
-        try(string("orange")),
-        try(string("ananas")),
+        attempt(string("apple")),
+        attempt(string("orange")),
+        attempt(string("ananas")),
     ]);
     let mut parser = sep_by(value, char(','));
     let result = parser.parse(stream).map(|t| t.0);
@@ -49,9 +49,9 @@ fn shared_stream_insufficent_backtrack() {
     let stream = BufferedStream::new(easy::Stream(State::new(IteratorStream::new(&mut iter))), 1);
 
     let value: &mut Parser<Input = _, Output = _, PartialState = _> = &mut choice([
-        try(string("apple")),
-        try(string("orange")),
-        try(string("ananas")),
+        attempt(string("apple")),
+        attempt(string("orange")),
+        attempt(string("ananas")),
     ]);
     let mut parser = sep_by(value, char(','));
     let result: Result<Vec<&str>, _> = parser.parse(stream).map(|t| t.0);

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -2,7 +2,7 @@ extern crate combine;
 
 use combine::parser::char::{digit, letter, string};
 use combine::parser::choice::{choice, optional};
-use combine::parser::combinator::{no_partial, not_followed_by, try};
+use combine::parser::combinator::{attempt, no_partial, not_followed_by};
 use combine::parser::error::unexpected;
 use combine::parser::item::{any, eof, position, token, value, Token};
 use combine::parser::range::{self, range};
@@ -210,9 +210,9 @@ mod tests_std {
 
     #[test]
     fn try_tests() {
-        // Ensure try adds error messages exactly once
+        // Ensure attempt adds error messages exactly once
         assert_eq!(
-            try(unexpected("test")).easy_parse(State::new("hi")),
+            attempt(unexpected("test")).easy_parse(State::new("hi")),
             Err(Errors {
                 position: SourcePosition { line: 1, column: 1 },
                 errors: vec![
@@ -222,7 +222,7 @@ mod tests_std {
             })
         );
         assert_eq!(
-            try(char('h').with(unexpected("test"))).easy_parse(State::new("hi")),
+            attempt(char('h').with(unexpected("test"))).easy_parse(State::new("hi")),
             Err(Errors {
                 position: SourcePosition { line: 1, column: 2 },
                 errors: vec![
@@ -387,7 +387,7 @@ mod tests_std {
     #[test]
     fn sequence_parser_resets_partial_state_issue_168() {
         assert_eq!(
-            take_until::<String, _>(try((char('a'), char('b')))).parse("aaab"),
+            take_until::<String, _>(attempt((char('a'), char('b')))).parse("aaab"),
             Ok((String::from("aa"), "ab"))
         );
     }
@@ -395,7 +395,7 @@ mod tests_std {
     #[test]
     fn parser_macro_must_impl_parse_mode_issue_168() {
         assert_eq!(
-            skip_until(try((char('a'), char('b')))).parse("aaab"),
+            skip_until(attempt((char('a'), char('b')))).parse("aaab"),
             Ok(((), "ab"))
         );
     }
@@ -403,7 +403,7 @@ mod tests_std {
     #[test]
     fn recognize_parser_issue_168() {
         assert_eq!(
-            range::recognize(skip_until(try((char('a'), char('b'))))).parse("aaab"),
+            range::recognize(skip_until(attempt((char('a'), char('b'))))).parse("aaab"),
             Ok(("aa", "ab"))
         );
     }
@@ -522,7 +522,7 @@ mod tests_std {
 
     #[test]
     fn choice_compose_on_error() {
-        let ident = |s| try(string(s));
+        let ident = |s| attempt(string(s));
         let mut parser = choice((ident("aa").skip(string(";")), choice((ident("cc"),))));
 
         assert_eq!(
@@ -538,7 +538,7 @@ mod tests_std {
 
     #[test]
     fn choice_compose_issue_175() {
-        let ident = |s| try(string(s));
+        let ident = |s| attempt(string(s));
         let mut parser = many::<Vec<_>, _>(position().and(choice((
             ident("aa").skip(string(";")),
             choice((ident("bb"), ident("cc"))),


### PR DESCRIPTION
Since `try` is reserved in Rust 2018, this adds a new function, `attempt`, that is equivalent to `try`. 

This PR is separated into 3 commits:
1. Adds the alias + docs
2. Deprecates `try`
3. Refactors all internal usages of `try` to `attempt`.
