### PR TITLE
Do not show the TODO on docs.rs

### DIFF
--- a/src/parser/combinator.rs
+++ b/src/parser/combinator.rs
@@ -46,7 +46,7 @@ where [
 }
 }
 
-/**
+/*
  * TODO :: Rename `Try` to `Attempt`
  * Because this is public, it's name cannot be changed without also making a breaking change.
  */


### PR DESCRIPTION
https://docs.rs/combine/3.6.0/combine/parser/combinator/struct.Try.html

Because `/**` comments are seen by rustdoc as documentation (TIL 😅), this todo was included in the build. 

This changes it to a regular comment that won't be included.