### PR TITLE
fix: Allow clippy to run on stable rust

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,9 +188,9 @@
 // inline(always) is only used on trivial functions returning parsers
 #![cfg_attr(
     feature = "cargo-clippy",
-    allow(clippy::inline_always, clippy::type_complexity)
+    allow(inline_always, type_complexity, too_many_arguments)
 )]
-#![cfg_attr(feature = "cargo-clippy", feature(tool_lints))]
+#![cfg_attr(feature = "cargo-clippy", allow(clippy_lint))]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[doc(inline)]

--- a/src/parser/combinator.rs
+++ b/src/parser/combinator.rs
@@ -124,7 +124,7 @@ where
 ///
 /// Note: if you're on the 2018 edition, you'll need to either use `r#try`, or [`attempt`](fn.attempt.html)
 #[deprecated(
-    since = "3.5",
+    since = "3.5.2",
     note = "try is a reserved keyword in Rust 2018. Use attempt instead."
 )]
 #[inline(always)]

--- a/src/parser/sequence.rs
+++ b/src/parser/sequence.rs
@@ -81,7 +81,6 @@ macro_rules! tuple_parser {
               $($id: Parser<Input=Input>),*
         {
             #[allow(dead_code)]
-            #[cfg_attr(feature = "cargo-clippy", allow(clippy::too_many_arguments))]
             fn add_errors(
                 input: &mut Input,
                 mut err: Tracked<Input::Error>,


### PR DESCRIPTION
Fixes #207 