### PR TITLE
Restore no-std buildability.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,9 @@ name = "combine"
 path = "src/lib.rs"
 
 [dependencies]
-ascii = "0.7.0"
-byteorder = "1.1.0"
-either = "1"
+ascii = { version = "0.9.1", default-features = false }
+byteorder = { version = "1.1.0", default-features = false }
+either = { version = "1", default-features = false }
 unreachable = "1.0.0"
 regex = { version = "0.2.0", optional = true }
 combine-regex-1 = { version = "1", path = "combine-regex-1", optional = true }
@@ -49,7 +49,7 @@ mp4 = []
 # Enables use of regex version 1 in the regex parsers
 regex-1 = ["combine-regex-1"]
 doc = ["regex", "regex-1"]
-std = ["memchr/use_std"]
+std = ["memchr/use_std", "either/use_std", "byteorder/std", "ascii/std"]
 
 [[bench]]
 name = "json"


### PR DESCRIPTION
This patch makes Cargo.toml select no-std features in dependencies.