### PR TITLE
Make char::string and similar functions generic over output lifetime to get better lifetime inference

### DIFF
--- a/src/parser/byte.rs
+++ b/src/parser/byte.rs
@@ -284,18 +284,18 @@ where
 }
 
 #[derive(Copy, Clone)]
-pub struct Bytes<I>(&'static [u8], PhantomData<I>)
+pub struct Bytes<'a, I>(&'static [u8], PhantomData<(&'a [u8], I)>)
 where
     I: Stream<Item = u8>,
     I::Error: ParseError<I::Item, I::Range, I::Position>;
 
-impl<'a, I> Parser for Bytes<I>
+impl<'a, 'b, I> Parser for Bytes<'a, I>
 where
-    I: Stream<Item = u8, Range = &'a [u8]>,
+    I: Stream<Item = u8, Range = &'b [u8]>,
     I::Error: ParseError<I::Item, I::Range, I::Position>,
 {
     type Input = I;
-    type Output = &'static [u8];
+    type Output = &'a [u8];
     type PartialState = ();
 
     #[inline]
@@ -329,28 +329,28 @@ where
 /// [`RangeStream`]: ../stream/trait.RangeStream.html
 /// [`range`]: ../range/fn.range.html
 #[inline(always)]
-pub fn bytes<'a, I>(s: &'static [u8]) -> Bytes<I>
+pub fn bytes<'a, 'b, I>(s: &'static [u8]) -> Bytes<'a, I>
 where
-    I: Stream<Item = u8, Range = &'a [u8]>,
+    I: Stream<Item = u8, Range = &'b [u8]>,
     I::Error: ParseError<I::Item, I::Range, I::Position>,
 {
     Bytes(s, PhantomData)
 }
 
 #[derive(Copy, Clone)]
-pub struct BytesCmp<C, I>(&'static [u8], C, PhantomData<I>)
+pub struct BytesCmp<'a, C, I>(&'static [u8], C, PhantomData<(&'a [u8], I)>)
 where
     I: Stream<Item = u8>,
     I::Error: ParseError<I::Item, I::Range, I::Position>;
 
-impl<'a, C, I> Parser for BytesCmp<C, I>
+impl<'a, 'b, C, I> Parser for BytesCmp<'a, C, I>
 where
     C: FnMut(u8, u8) -> bool,
-    I: Stream<Item = u8, Range = &'a [u8]>,
+    I: Stream<Item = u8, Range = &'b [u8]>,
     I::Error: ParseError<I::Item, I::Range, I::Position>,
 {
     type Input = I;
-    type Output = &'static [u8];
+    type Output = &'a [u8];
     type PartialState = ();
 
     #[inline]
@@ -385,10 +385,10 @@ where
 /// [`RangeStream`]: ../stream/trait.RangeStream.html
 /// [`range`]: ../range/fn.range.html
 #[inline(always)]
-pub fn bytes_cmp<'a, C, I>(s: &'static [u8], cmp: C) -> BytesCmp<C, I>
+pub fn bytes_cmp<'a, 'b, C, I>(s: &'static [u8], cmp: C) -> BytesCmp<'a, C, I>
 where
     C: FnMut(u8, u8) -> bool,
-    I: Stream<Item = u8, Range = &'a [u8]>,
+    I: Stream<Item = u8, Range = &'b [u8]>,
     I::Error: ParseError<I::Item, I::Range, I::Position>,
 {
     BytesCmp(s, cmp, PhantomData)

--- a/src/parser/char.rs
+++ b/src/parser/char.rs
@@ -309,17 +309,17 @@ fn eq(l: char, r: char) -> bool {
 }
 
 #[derive(Copy, Clone)]
-pub struct Str<I>(&'static str, PhantomData<fn(I) -> I>)
+pub struct Str<'a, I>(&'static str, PhantomData<(&'a str, fn(I) -> I)>)
 where
     I: Stream<Item = char>,
     I::Error: ParseError<I::Item, I::Range, I::Position>;
-impl<I> Parser for Str<I>
+impl<'a, I> Parser for Str<'a, I>
 where
     I: Stream<Item = char>,
     I::Error: ParseError<I::Item, I::Range, I::Position>,
 {
     type Input = I;
-    type Output = &'static str;
+    type Output = &'a str;
     type PartialState = ();
 
     #[inline]
@@ -347,7 +347,7 @@ where
 /// # }
 /// ```
 #[inline(always)]
-pub fn string<I>(s: &'static str) -> Str<I>
+pub fn string<'a, I>(s: &'static str) -> Str<'a, I>
 where
     I: Stream<Item = char>,
     I::Error: ParseError<I::Item, I::Range, I::Position>,
@@ -356,18 +356,18 @@ where
 }
 
 #[derive(Copy, Clone)]
-pub struct StrCmp<C, I>(&'static str, C, PhantomData<fn(I) -> I>)
+pub struct StrCmp<'a, C, I>(&'static str, C, PhantomData<(&'a str, fn(I) -> I)>)
 where
     I: Stream<Item = char>,
     I::Error: ParseError<I::Item, I::Range, I::Position>;
-impl<C, I> Parser for StrCmp<C, I>
+impl<'a, C, I> Parser for StrCmp<'a, C, I>
 where
     C: FnMut(char, char) -> bool,
     I: Stream<Item = char>,
     I::Error: ParseError<I::Item, I::Range, I::Position>,
 {
     type Input = I;
-    type Output = &'static str;
+    type Output = &'a str;
     type PartialState = ();
 
     #[inline]
@@ -396,7 +396,7 @@ where
 /// # }
 /// ```
 #[inline(always)]
-pub fn string_cmp<C, I>(s: &'static str, cmp: C) -> StrCmp<C, I>
+pub fn string_cmp<'a, C, I>(s: &'static str, cmp: C) -> StrCmp<'a, C, I>
 where
     C: FnMut(char, char) -> bool,
     I: Stream<Item = char>,

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -1,6 +1,7 @@
 extern crate combine;
 
-use combine::parser::char::{digit, letter, string};
+use combine::parser::char::{digit, letter, string, string_cmp};
+use combine::parser::byte::{bytes, bytes_cmp};
 use combine::parser::choice::{choice, optional};
 use combine::parser::combinator::{attempt, no_partial, not_followed_by};
 use combine::parser::error::unexpected;
@@ -566,5 +567,21 @@ mod tests_std {
                 Error::Expected("letter".into()),
             ]),
         );
+    }
+
+    #[test]
+    fn lifetime_inference() {
+        fn _string<'a>(source: &'a str) {
+            range::take(1).or(string("a")).parse(source).ok();
+            range::take(1).or(string_cmp("a", |x, y| x == y)).parse(source).ok();
+            let _: &'static str = string("a").parse(source).unwrap().0;
+            let _: &'static str = string_cmp("a", |x, y| x == y).parse(source).unwrap().0;
+        }
+        fn _bytes<'a>(source: &'a [u8]) {
+            range::take(1).or(bytes(&[0u8])).parse(source).ok();
+            range::take(1).or(bytes_cmp(&[0u8], |x, y| x == y)).parse(source).ok();
+            let _: &'static [u8] = bytes(&[0u8]).parse(source).unwrap().0;
+            let _: &'static [u8] = bytes_cmp(&[0u8], |x, y| x == y).parse(source).unwrap().0;
+        }
     }
 }


### PR DESCRIPTION
This code:
```rust
fn func<'a>(source: &'a str) {
    take(1).or(string("a")).parse(source);
}
```
produces a compile error "cannot infer an appropriate lifetime due to conflicting requirements" due to limitation of the current compiler or something.
I can workaround this by changing `string("a")` to `string("a").map(|x| x)` but it would be better if the code just works.
In order to solve this problem, I made `string` to parametrized over a lifetime and this lifetime is used for Parser::Output. I also applied this to `string_cmp`, `bytes`, `bytes_cmp`.
This is a breaking change for a code like "bytes::<'a, _>(&[0u8])".