### PR TITLE
Reset count state after extending the iterator

### DIFF
--- a/src/parser/repeat.rs
+++ b/src/parser/repeat.rs
@@ -50,6 +50,7 @@ where
                 .inspect(|_| *count += 1),
         );
 
+        *count = 0;
         iter.into_result_fast(elements)
     }
 

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -6,7 +6,7 @@ use combine::parser::combinator::{attempt, no_partial, not_followed_by};
 use combine::parser::error::unexpected;
 use combine::parser::item::{any, eof, position, token, value, Token};
 use combine::parser::range::{self, range};
-use combine::parser::repeat::{count_min_max, many, sep_by, sep_end_by1, skip_until, take_until};
+use combine::parser::repeat::{count, count_min_max, many, sep_by, sep_end_by1, skip_until, take_until};
 use combine::Parser;
 
 #[test]
@@ -43,6 +43,8 @@ fn not_followed_by_does_not_consume_any_input() {
 #[cfg(feature = "std")]
 mod tests_std {
     use super::*;
+    use combine::parser::byte::{alpha_num, bytes};
+    use combine::parser::byte::num::be_u32;
     use combine::parser::char::{char, digit, letter};
     use combine::stream::easy::{Error, Errors, ParseError};
     use combine::stream::state::{SourcePosition, State};
@@ -566,5 +568,25 @@ mod tests_std {
                 Error::Expected("letter".into()),
             ]),
         );
+    }
+
+    #[test]
+    fn test_nested_count_overflow() {
+        let key = || count::<Vec<_>, _>(64, alpha_num());
+        let value_bytes = || be_u32()
+            .then_partial(|&mut size| count::<Vec<_>, _>(size as usize, any()));
+        let value_messages = (be_u32(), be_u32())
+            .then_partial(|&mut (_body_size, message_count)| {
+                count::<Vec<_>, _>(message_count as usize, value_bytes())
+            });
+        let put = (bytes(b"PUT"), key())
+            .map(|(_, key)| key)
+            .and(value_messages);
+
+        let parser = || put.map(|(_, messages)| messages);
+
+        let command = &b"PUTkey\x00\x00\x00\x12\x00\x00\x00\x02\x00\x00\x00\x04\xDE\xAD\xBE\xEF\x00\x00\x00\x02\xBE\xEF"[..];
+        let result = parser().parse(command).unwrap();
+        assert_eq!(2, result.0.len());
     }
 }


### PR DESCRIPTION
When working on a parser, I started to get `attempt to subtract with overflow` panic coming from the Count combinator:

```
thread 'tests_std::test_nested_count_overflow' panicked at 'attempt to subtract with overflow', /home/blake/src/combine/src/parser/repeat.rs:50:23
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
stack backtrace:
   0: std::sys::unix::backtrace::tracing::imp::unwind_backtrace
             at libstd/sys/unix/backtrace/tracing/gcc_s.rs:49
   1: std::sys_common::backtrace::print
             at libstd/sys_common/backtrace.rs:71
             at libstd/sys_common/backtrace.rs:59
   2: std::panicking::default_hook::{{closure}}
             at libstd/panicking.rs:211
   3: std::panicking::default_hook
             at libstd/panicking.rs:221
   4: std::panicking::rust_panic_with_hook
             at libstd/panicking.rs:477
   5: std::panicking::continue_panic_fmt
             at libstd/panicking.rs:391
   6: rust_begin_unwind
             at libstd/panicking.rs:326
   7: core::panicking::panic_fmt
             at libcore/panicking.rs:77
   8: core::panicking::panic
             at libcore/panicking.rs:52
   9: <combine::parser::repeat::Count<F, P> as combine::parser::Parser>::parse_mode_impl
             at ./src/parser/repeat.rs:50
  10: combine::parser::ParseMode::parse_consumed
             at ./src/parser/mod.rs:1025
  11: <combine::parser::sequence::ThenPartial<P, F> as combine::parser::Parser>::parse_mode_impl
             at ./src/parser/mod.rs:374
             at ./src/parser/sequence.rs:660
  12: <combine::parser::repeat::Iter<'a, P, S, M> as core::iter::iterator::Iterator>::next
             at ./src/parser/mod.rs:334
             at ./src/parser/mod.rs:58
             at ./src/parser/mod.rs:960
             at ./src/parser/mod.rs:354
             at ./src/parser/mod.rs:334
             at ./src/parser/repeat.rs:340
  13: <&'a mut I as core::iter::iterator::Iterator>::next
             at libcore/iter/iterator.rs:2562
  14: <core::iter::Take<I> as core::iter::iterator::Iterator>::next
             at libcore/iter/mod.rs:2366
  15: <core::iter::Inspect<I, F> as core::iter::iterator::Iterator>::next
             at libcore/iter/mod.rs:3066
  16: <alloc::vec::Vec<T>>::extend_desugared
             at liballoc/vec.rs:1980
  17: <alloc::vec::Vec<T> as alloc::vec::SpecExtend<T, I>>::spec_extend
             at liballoc/vec.rs:1877
  18: <alloc::vec::Vec<T> as core::iter::traits::Extend<T>>::extend
             at liballoc/vec.rs:1841
  19: <combine::parser::repeat::Count<F, P> as combine::parser::Parser>::parse_mode_impl
             at ./src/parser/repeat.rs:48
  20: combine::parser::ParseMode::parse_consumed
             at ./src/parser/mod.rs:1025
  21: <combine::parser::sequence::ThenPartial<P, F> as combine::parser::Parser>::parse_mode_impl
             at ./src/parser/mod.rs:374
             at ./src/parser/sequence.rs:660
  22: combine::parser::sequence::<impl combine::parser::Parser for (A, B)>::parse_mode_impl
             at ./src/parser/mod.rs:334
             at ./src/parser/sequence.rs:189
  23: <combine::parser::combinator::Map<P, F> as combine::parser::Parser>::parse_mode_impl
             at ./src/parser/mod.rs:334
             at ./src/parser/combinator.rs:237
  24: combine::parser::Parser::parse_stream_consumed
             at ./src/parser/mod.rs:334
             at ./src/parser/mod.rs:58
             at ./src/parser/mod.rs:225
  25: combine::parser::Parser::parse
             at ./src/parser/mod.rs:206
             at ./src/parser/mod.rs:174
  26: parser::tests_std::test_nested_count_overflow
             at tests/parser.rs:589
  27: parser::tests_std::test_nested_count_overflow::{{closure}}
             at tests/parser.rs:574
  28: core::ops::function::FnOnce::call_once
             at libcore/ops/function.rs:238
  29: <F as alloc::boxed::FnBox<A>>::call_box
             at libtest/lib.rs:1461
             at libcore/ops/function.rs:238
             at liballoc/boxed.rs:646
  30: __rust_maybe_catch_panic
             at libpanic_unwind/lib.rs:103
```

I'm not sure exactly what's happening, but it seems that the *count ref is being preserved between `count` combinator calls. The attached PR makes my parser not panic anymore, and the attached test pass, but I'm a little puzzled why the *count state is being preserved between calls. Any help or insight would be really appreciated.

Thanks so much for the great library, it's been really great so far!