### PR TITLE
Fix two inconsisties regarding EOI

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -414,11 +414,10 @@ impl<Item, Range> StreamError<Item, Range> for UnexpectedParse {
     where
         T: StreamError<Item, Range>,
     {
-        let msg = match self {
-            UnexpectedParse::Unexpected => "parse",
-            UnexpectedParse::Eoi => "end of input",
-        };
-        T::unexpected_static_message(msg)
+        match self {
+            UnexpectedParse::Unexpected => T::unexpected_static_message("parse"),
+            UnexpectedParse::Eoi => T::end_of_input(),
+        }
     }
 }
 
@@ -442,7 +441,10 @@ where
 
     #[inline]
     fn add(&mut self, err: Self::StreamError) {
-        *self = err;
+        *self = match (&self, err) {
+            (&UnexpectedParse::Eoi, _) => UnexpectedParse::Eoi,
+            (_, err) => err,
+        };
     }
 
     #[inline]
@@ -581,7 +583,10 @@ where
 
     #[inline]
     fn add(&mut self, err: Self::StreamError) {
-        *self = err;
+        *self = match (&self, err) {
+            (&StringStreamError::Eoi, _) => StringStreamError::Eoi,
+            (_, err) => err,
+        };
     }
 
     #[inline]

--- a/src/error.rs
+++ b/src/error.rs
@@ -441,8 +441,8 @@ where
 
     #[inline]
     fn add(&mut self, err: Self::StreamError) {
-        *self = match (&self, err) {
-            (&UnexpectedParse::Eoi, _) => UnexpectedParse::Eoi,
+        *self = match (*self, err) {
+            (UnexpectedParse::Eoi, _) => UnexpectedParse::Eoi,
             (_, err) => err,
         };
     }
@@ -583,8 +583,8 @@ where
 
     #[inline]
     fn add(&mut self, err: Self::StreamError) {
-        *self = match (&self, err) {
-            (&StringStreamError::Eoi, _) => StringStreamError::Eoi,
+        *self = match (*self, err) {
+            (StringStreamError::Eoi, _) => StringStreamError::Eoi,
             (_, err) => err,
         };
     }


### PR DESCRIPTION
1.
 - `easy::Errors` is EOI if any of it's added `StreamError`s is EOI
 while
 - `UnexpectedParse`/`StringStreamError` is EOI if the last added `StreamError` is EOI
2.
 - `StringStreamError::into_other()` propagates EOI while `UnexpectedParse` stringifies it.

50% chance that I fixed 1. the corrent way :smile: 