### PR TITLE
feat: Allow ReadStream parsers to use &[u8] in errors

### DIFF
--- a/src/parser/byte.rs
+++ b/src/parser/byte.rs
@@ -718,6 +718,8 @@ pub mod num {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::stream::{buffered, state::State, ReadStream};
+
     #[test]
     fn memslice_basic() {
         let haystack = b"abc123";
@@ -732,5 +734,15 @@ mod tests {
 
         let haystack3 = b"aaabaaaa";
         assert_eq!(memslice(b"aaaa", haystack3), Some(4));
+    }
+
+    #[test]
+    fn bytes_read_stream() {
+        assert!(bytes(b"abc")
+            .parse(buffered::Stream::new(
+                State::new(ReadStream::new("abc".as_bytes())),
+                1
+            ))
+            .is_ok());
     }
 }

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -916,9 +916,9 @@ pub struct ReadStream<R> {
 #[cfg(feature = "std")]
 impl<R: Read> StreamOnce for ReadStream<R> {
     type Item = u8;
-    type Range = u8;
+    type Range = &'static [u8];
     type Position = usize;
-    type Error = Errors<u8, u8, usize>;
+    type Error = Errors<Self::Item, Self::Range, usize>;
 
     #[inline]
     fn uncons(&mut self) -> Result<u8, StreamErrorFor<Self>> {


### PR DESCRIPTION
Fixes #249

BREAKING CHANGE