### PR TITLE
Replace unreachable crate with intrinsic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,7 +124,6 @@ dependencies = [
  "regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -542,14 +541,6 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "unreachable"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "utf8-ranges"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -562,11 +553,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "version_check"
 version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "void"
-version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -686,11 +672,9 @@ dependencies = [
 "checksum ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "535c204ee4d8434478593480b8f86ab45ec9aae0e83c568ca81abf0fd0e88f86"
 "checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
-"checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
 "checksum utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
-"checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "9d9d7ed3431229a144296213105a390676cc49c9b6a72bd19f3176c98e129fa1"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ path = "src/lib.rs"
 ascii = { version = "0.9.1", default-features = false }
 byteorder = { version = "1.1.0", default-features = false }
 either = { version = "1", default-features = false }
-unreachable = "1.0.0"
 regex = { version = "1", optional = true }
 memchr = { version = "2.2", default-features = false }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -671,7 +671,6 @@ extern crate bytes;
 pub extern crate either;
 
 extern crate memchr;
-extern crate unreachable;
 
 /// Internal API. May break without a semver bump
 macro_rules! forward_parser {

--- a/src/parser/sequence.rs
+++ b/src/parser/sequence.rs
@@ -49,7 +49,7 @@ where
     unsafe fn unwrap_value(&mut self) -> T {
         match self.value.take() {
             Some(t) => t,
-            None => ::unreachable::unreachable(),
+            None => std::hint::unreachable_unchecked(),
         }
     }
 }

--- a/src/parser/sequence.rs
+++ b/src/parser/sequence.rs
@@ -49,7 +49,7 @@ where
     unsafe fn unwrap_value(&mut self) -> T {
         match self.value.take() {
             Some(t) => t,
-            None => std::hint::unreachable_unchecked(),
+            None => core::hint::unreachable_unchecked(),
         }
     }
 }


### PR DESCRIPTION
Replaces an old and unnecessary crate with the corresponding intrinsic that now exists in the language.