### PR TITLE
extend dispatch! macro to work with match guards

### DIFF
--- a/src/parser/choice.rs
+++ b/src/parser/choice.rs
@@ -775,8 +775,8 @@ macro_rules! dispatch_parser_impl {
 
 #[macro_export]
 macro_rules! dispatch_inner {
-    ($expr_ident: ident [$first_ident: ident $($id: ident)*] [$($collected: tt)*] $($pat: pat)|+ => $expr: expr, $($rest_alt: tt)*) => {
-        $crate::dispatch_inner!{ $expr_ident [ $($id)* ] [$($collected)* $first_ident $($pat)|+ => $expr,] $($rest_alt)*}
+    ($expr_ident: ident [$first_ident: ident $($id: ident)*] [$($collected: tt)*] $($pat: pat)|+ $(if $pred:expr)* => $expr: expr, $($rest_alt: tt)*) => {
+        $crate::dispatch_inner!{ $expr_ident [ $($id)* ] [$($collected)* $first_ident $($pat)|+ $(if $pred)* => $expr,] $($rest_alt)*}
     };
     ($expr_ident: ident [$($id: ident)*] [$($collected: tt)*]) => {
         $crate::dispatch_inner!{ $expr_ident $($collected)* }
@@ -784,10 +784,10 @@ macro_rules! dispatch_inner {
     ($expr_ident: ident [$($ident_tt: tt)*]) => {
         unreachable!()
     };
-    ($expr_ident: ident $( $ident: ident $($pat: pat)|+ => $expr: expr,)+ ) => {
+    ($expr_ident: ident $( $ident: ident $($pat: pat)|+ $(if $pred:expr)* => $expr: expr,)+ ) => {
         match $expr_ident {
             $(
-                $($pat)|+ => Dispatch::$ident(check_parser($expr)),
+                $($pat)|+ $(if $pred)* => Dispatch::$ident(check_parser($expr)),
             )+
         }
     }
@@ -795,7 +795,7 @@ macro_rules! dispatch_inner {
 
 #[macro_export]
 macro_rules! dispatch {
-    ($match_expr: expr; $( $($pat: pat)|+ => $expr: expr ),+ $(,)? ) => {
+    ($match_expr: expr; $( $($pat: pat)|+ $(if $pred:expr)* => $expr: expr ),+ $(,)? ) => {
         {
             $crate::dispatch_parser_impl!{ Dispatch [A B C D E F G H I J K L M N O P Q R S T U V X Y Z] [] $($expr,)+ }
 
@@ -804,7 +804,7 @@ macro_rules! dispatch {
             let e = $match_expr;
             let parser = $crate::dispatch_inner!(e [A B C D E F G H I J K L M N O P Q R S T U V X Y Z] []
                 $(
-                    $($pat)|+ => $expr,
+                    $($pat)|+ $(if $pred)* => $expr,
                 )*
             );
             parser

--- a/src/parser/choice.rs
+++ b/src/parser/choice.rs
@@ -775,8 +775,8 @@ macro_rules! dispatch_parser_impl {
 
 #[macro_export]
 macro_rules! dispatch_inner {
-    ($expr_ident: ident [$first_ident: ident $($id: ident)*] [$($collected: tt)*] $($pat: pat)|+ $(if $pred:expr)* => $expr: expr, $($rest_alt: tt)*) => {
-        $crate::dispatch_inner!{ $expr_ident [ $($id)* ] [$($collected)* $first_ident $($pat)|+ $(if $pred)* => $expr,] $($rest_alt)*}
+    ($expr_ident: ident [$first_ident: ident $($id: ident)*] [$($collected: tt)*] $($pat: pat)|+ $(if $pred:expr)? => $expr: expr, $($rest_alt: tt)*) => {
+        $crate::dispatch_inner!{ $expr_ident [ $($id)* ] [$($collected)* $first_ident $($pat)|+ $(if $pred)? => $expr,] $($rest_alt)*}
     };
     ($expr_ident: ident [$($id: ident)*] [$($collected: tt)*]) => {
         $crate::dispatch_inner!{ $expr_ident $($collected)* }
@@ -784,10 +784,10 @@ macro_rules! dispatch_inner {
     ($expr_ident: ident [$($ident_tt: tt)*]) => {
         unreachable!()
     };
-    ($expr_ident: ident $( $ident: ident $($pat: pat)|+ $(if $pred:expr)* => $expr: expr,)+ ) => {
+    ($expr_ident: ident $( $ident: ident $($pat: pat)|+ $(if $pred:expr)? => $expr: expr,)+ ) => {
         match $expr_ident {
             $(
-                $($pat)|+ $(if $pred)* => Dispatch::$ident(check_parser($expr)),
+                $($pat)|+ $(if $pred)? => Dispatch::$ident(check_parser($expr)),
             )+
         }
     }
@@ -795,7 +795,7 @@ macro_rules! dispatch_inner {
 
 #[macro_export]
 macro_rules! dispatch {
-    ($match_expr: expr; $( $($pat: pat)|+ $(if $pred:expr)* => $expr: expr ),+ $(,)? ) => {
+    ($match_expr: expr; $( $($pat: pat)|+ $(if $pred:expr)? => $expr: expr ),+ $(,)? ) => {
         {
             $crate::dispatch_parser_impl!{ Dispatch [A B C D E F G H I J K L M N O P Q R S T U V X Y Z] [] $($expr,)+ }
 
@@ -804,7 +804,7 @@ macro_rules! dispatch {
             let e = $match_expr;
             let parser = $crate::dispatch_inner!(e [A B C D E F G H I J K L M N O P Q R S T U V X Y Z] []
                 $(
-                    $($pat)|+ $(if $pred)* => $expr,
+                    $($pat)|+ $(if $pred)? => $expr,
                 )*
             );
             parser
@@ -833,7 +833,8 @@ mod tests {
             dispatch!(e;
                 'a' => token('a'),
                 'b' => token('b'),
-                _ => token('c')
+                t if t == 'c' => token('c'),
+                _ => token('d')
             )
         });
         assert_eq!(parser.easy_parse("aa"), Ok(('a', "")));


### PR DESCRIPTION
Enables forms such as:

```rust
dispatch!(foo
    "one_value" => parser_for_one_value(),
    foo if foo[0] == "x" => parser_when_starting_with_x(),
    _ => unexpected_any("whatever"));
```