### PR TITLE
feat: Rename Consumed to Commit and Empty to Peek

### DIFF
--- a/benches/json.rs
+++ b/benches/json.rs
@@ -11,7 +11,7 @@ use std::{collections::HashMap, fs::File, io::Read, path::Path};
 
 use {
     combine::{
-        error::{Consumed, ParseError},
+        error::{Commit, ParseError},
         parser::{
             char::{char, digit, spaces, string},
             choice::{choice, optional},
@@ -125,7 +125,7 @@ where
         });
         match c {
             '\\' => consumed.combine(|_| back_slash_char.parse_stream(input).into_result()),
-            '"' => Err(Consumed::Empty(
+            '"' => Err(Commit::Peek(
                 Input::Error::empty(input.position()).into(),
             )),
             _ => Ok((c, consumed)),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -730,7 +730,7 @@ mod std_tests {
         },
     };
 
-    use super::{easy::Error, error::Consumed, stream::IteratorStream, *};
+    use super::{easy::Error, error::Commit, stream::IteratorStream, *};
 
     #[test]
     fn optional_error_consume() {
@@ -753,14 +753,14 @@ mod std_tests {
                 if c.is_alphanumeric() {
                     input.reset(before).unwrap();
                     let e = Error::Unexpected(c.into());
-                    Err(Consumed::Empty(
+                    Err(Commit::Peek(
                         easy::Errors::new(input.position(), e).into(),
                     ))
                 } else {
-                    Ok(((), Consumed::Empty(())))
+                    Ok(((), Commit::Peek(())))
                 }
             }
-            Err(_) => Ok(((), Consumed::Empty(()))),
+            Err(_) => Ok(((), Commit::Peek(()))),
         }
     }
 
@@ -819,7 +819,7 @@ mod std_tests {
             .map(|t| t.1)
             .parse_stream(&mut parsed_state)
             .into_result();
-        let state = Consumed::Consumed(position::Stream {
+        let state = Commit::Commit(position::Stream {
             positioner: SourcePosition { line: 3, column: 1 },
             input: "",
         });

--- a/src/parser/byte.rs
+++ b/src/parser/byte.rs
@@ -491,7 +491,7 @@ pub mod num {
                         for elem in &mut *buffer {
                             *elem = ctry!(uncons(input)).0;
                         }
-                        ConsumedOk(B::$read_name(buffer))
+                        CommitOk(B::$read_name(buffer))
                     })();
                     if result.is_err() {
                         ctry!(input.reset(checkpoint).consumed());

--- a/src/parser/choice.rs
+++ b/src/parser/choice.rs
@@ -147,8 +147,8 @@ macro_rules! do_choice {
     ) => { {
         let mut error = Tracked::from(merge!($($error)+));
         // If offset != 1 then the nested parser is a sequence of parsers where 1 or
-        // more parsers returned `EmptyOk` before the parser finally failed with
-        // `EmptyErr`. Since we lose the offsets of the nested parsers when we merge
+        // more parsers returned `PeekOk` before the parser finally failed with
+        // `PeekErr`. Since we lose the offsets of the nested parsers when we merge
         // the errors we must first extract the errors before we do the merge.
         // If the offset == 0 on the other hand (which should be the common case) then
         // we can delay the addition of the error since we know for certain that only
@@ -160,7 +160,7 @@ macro_rules! do_choice {
                 error.offset = ErrorOffset(0);
             }
         )+
-        EmptyErr(error)
+        PeekErr(error)
     } };
     (
         $input: ident
@@ -174,18 +174,18 @@ macro_rules! do_choice {
         let parser = $head;
         let mut state = $head::PartialState::default();
         match parser.parse_mode(crate::parser::FirstMode, $input, &mut state) {
-            ConsumedOk(x) => ConsumedOk(x),
-            EmptyOk(x) => EmptyOk(x),
-            ConsumedErr(err) => {
-                // If we get `ConsumedErr` but the input is the same this is a partial parse we
+            CommitOk(x) => CommitOk(x),
+            PeekOk(x) => PeekOk(x),
+            CommitErr(err) => {
+                // If we get `CommitErr` but the input is the same this is a partial parse we
                 // cannot commit to so leave the state as `Empty` to retry all the parsers
                 // on the next call to  `parse_partial`
                 if $input.position() != $before_position {
                     *$state = self::$partial_state::$head(state);
                 }
-                ConsumedErr(err)
+                CommitErr(err)
             }
-            EmptyErr($head) => {
+            PeekErr($head) => {
                 ctry!($input.reset($before.clone()).consumed());
                 do_choice!(
                     $input
@@ -409,18 +409,18 @@ where
         ctry!(input.reset(before.clone()).consumed());
 
         match self_[i].parse_mode(mode, input, child_state) {
-            consumed_err @ ConsumedErr(_) => {
+            consumed_err @ CommitErr(_) => {
                 *index_state = i + 1;
                 return consumed_err;
             }
-            EmptyErr(err) => {
+            PeekErr(err) => {
                 prev_err = match prev_err {
                     None => Some(err),
                     Some(mut prev_err) => {
                         if prev_err.offset != ErrorOffset(1) {
                             // First add the errors of all the preceding parsers which did not
-                            // have a sequence of parsers returning `EmptyOk` before failing
-                            // with `EmptyErr`.
+                            // have a sequence of parsers returning `PeekOk` before failing
+                            // with `PeekErr`.
                             let offset = prev_err.offset;
                             for p in &mut self_[last_parser_having_non_1_offset..(i - 1)] {
                                 prev_err.offset = ErrorOffset(1);
@@ -438,13 +438,13 @@ where
                     }
                 };
             }
-            ok @ ConsumedOk(_) | ok @ EmptyOk(_) => {
+            ok @ CommitOk(_) | ok @ PeekOk(_) => {
                 *index_state = 0;
                 return ok;
             }
         }
     }
-    EmptyErr(match prev_err {
+    PeekErr(match prev_err {
         None => Input::Error::from_error(
             input.position(),
             StreamError::message_static_message("parser choice is empty"),
@@ -651,12 +651,12 @@ where
     {
         let before = input.checkpoint();
         match self.0.parse_mode(mode, input, state) {
-            EmptyOk(x) => EmptyOk(Some(x)),
-            ConsumedOk(x) => ConsumedOk(Some(x)),
-            ConsumedErr(err) => ConsumedErr(err),
-            EmptyErr(_) => {
+            PeekOk(x) => PeekOk(Some(x)),
+            CommitOk(x) => CommitOk(Some(x)),
+            CommitErr(err) => CommitErr(err),
+            PeekErr(_) => {
                 ctry!(input.reset(before).consumed());
-                EmptyOk(None)
+                PeekOk(None)
             }
         }
     }

--- a/src/parser/combinator.rs
+++ b/src/parser/combinator.rs
@@ -135,8 +135,8 @@ where
     forward_parser!(Input, add_error add_consumed_expected_error parser_count, 0);
 }
 
-/// `attempt(p)` behaves as `p` except it acts as if the parser hadn't consumed any input if `p` fails
-/// after consuming input.
+/// `attempt(p)` behaves as `p` except it always acts as `p` peeked instead of commited on its
+/// parse.
 ///
 /// ```
 /// # extern crate combine;
@@ -392,9 +392,7 @@ where
                     if input.is_partial() && input_at_eof(input) {
                         ctry!(input.reset(checkpoint).consumed());
                     }
-                    CommitErr(
-                        <Input as StreamOnce>::Error::from_error(position, err.into()).into(),
-                    )
+                    CommitErr(<Input as StreamOnce>::Error::from_error(position, err.into()).into())
                 }
             },
             PeekErr(err) => PeekErr(err),

--- a/src/parser/combinator.rs
+++ b/src/parser/combinator.rs
@@ -39,8 +39,8 @@ where
         let result = self.0.parse_mode(mode, input, state);
         ctry!(input.reset(checkpoint).consumed());
         match result {
-            ConsumedOk(_) | EmptyOk(_) => EmptyErr(Input::Error::empty(input.position()).into()),
-            ConsumedErr(_) | EmptyErr(_) => EmptyOk(()),
+            CommitOk(_) | PeekOk(_) => PeekErr(Input::Error::empty(input.position()).into()),
+            CommitErr(_) | PeekErr(_) => PeekOk(()),
         }
     }
 
@@ -121,12 +121,12 @@ where
         M: ParseMode,
     {
         match self.0.parse_consumed_mode(mode, input, state) {
-            v @ ConsumedOk(_) | v @ EmptyOk(_) | v @ EmptyErr(_) => v,
-            ConsumedErr(err) => {
+            v @ CommitOk(_) | v @ PeekOk(_) | v @ PeekErr(_) => v,
+            CommitErr(err) => {
                 if input.is_partial() && err.is_unexpected_end_of_input() {
-                    ConsumedErr(err)
+                    CommitErr(err)
                 } else {
-                    EmptyErr(err.into())
+                    PeekErr(err.into())
                 }
             }
         }
@@ -176,7 +176,7 @@ where
         let result = self.0.parse_lazy(input);
         ctry!(input.reset(before).consumed());
         let (o, _input) = ctry!(result);
-        EmptyOk(o)
+        PeekOk(o)
     }
 
     forward_parser!(Input, add_error add_consumed_expected_error parser_count, 0);
@@ -229,10 +229,10 @@ where
         M: ParseMode,
     {
         match self.0.parse_mode(mode, input, state) {
-            ConsumedOk(x) => ConsumedOk((self.1)(x)),
-            EmptyOk(x) => EmptyOk((self.1)(x)),
-            ConsumedErr(err) => ConsumedErr(err),
-            EmptyErr(err) => EmptyErr(err),
+            CommitOk(x) => CommitOk((self.1)(x)),
+            PeekOk(x) => PeekOk((self.1)(x)),
+            CommitErr(err) => CommitErr(err),
+            PeekErr(err) => PeekErr(err),
         }
     }
 
@@ -274,10 +274,10 @@ where
         M: ParseMode,
     {
         match self.0.parse_mode(mode, input, state) {
-            ConsumedOk(x) => ConsumedOk((self.1)(x, input)),
-            EmptyOk(x) => EmptyOk((self.1)(x, input)),
-            ConsumedErr(err) => ConsumedErr(err),
-            EmptyErr(err) => EmptyErr(err),
+            CommitOk(x) => CommitOk((self.1)(x, input)),
+            PeekOk(x) => PeekOk((self.1)(x, input)),
+            CommitErr(err) => CommitErr(err),
+            PeekErr(err) => PeekErr(err),
         }
     }
 
@@ -319,16 +319,16 @@ where
         M: ParseMode,
     {
         match self.0.parse_mode(mode, input, state) {
-            EmptyOk(o) => match (self.1)(o) {
-                Ok(x) => EmptyOk(x),
-                Err(err) => EmptyErr(err.into()),
+            PeekOk(o) => match (self.1)(o) {
+                Ok(x) => PeekOk(x),
+                Err(err) => PeekErr(err.into()),
             },
-            ConsumedOk(o) => match (self.1)(o) {
-                Ok(x) => ConsumedOk(x),
-                Err(err) => ConsumedErr(err.into()),
+            CommitOk(o) => match (self.1)(o) {
+                Ok(x) => CommitOk(x),
+                Err(err) => CommitErr(err.into()),
             },
-            EmptyErr(err) => EmptyErr(err),
-            ConsumedErr(err) => ConsumedErr(err),
+            PeekErr(err) => PeekErr(err),
+            CommitErr(err) => CommitErr(err),
         }
     }
 
@@ -373,32 +373,32 @@ where
         let position = input.position();
         let checkpoint = input.checkpoint();
         match self.0.parse_mode(mode, input, state) {
-            EmptyOk(o) => match (self.1)(o) {
-                Ok(o) => EmptyOk(o),
+            PeekOk(o) => match (self.1)(o) {
+                Ok(o) => PeekOk(o),
                 Err(err) => {
                     let err = <Input as StreamOnce>::Error::from_error(position, err.into());
 
                     if input.is_partial() && input_at_eof(input) {
                         ctry!(input.reset(checkpoint).consumed());
-                        ConsumedErr(err)
+                        CommitErr(err)
                     } else {
-                        EmptyErr(err.into())
+                        PeekErr(err.into())
                     }
                 }
             },
-            ConsumedOk(o) => match (self.1)(o) {
-                Ok(o) => ConsumedOk(o),
+            CommitOk(o) => match (self.1)(o) {
+                Ok(o) => CommitOk(o),
                 Err(err) => {
                     if input.is_partial() && input_at_eof(input) {
                         ctry!(input.reset(checkpoint).consumed());
                     }
-                    ConsumedErr(
+                    CommitErr(
                         <Input as StreamOnce>::Error::from_error(position, err.into()).into(),
                     )
                 }
             },
-            EmptyErr(err) => EmptyErr(err),
-            ConsumedErr(err) => ConsumedErr(err),
+            PeekErr(err) => PeekErr(err),
+            CommitErr(err) => CommitErr(err),
         }
     }
 
@@ -435,7 +435,7 @@ impl<F, P> Recognize<F, P> {
         F: Default + Extend<Input::Token>,
     {
         match result {
-            EmptyOk(_) => {
+            PeekOk(_) => {
                 let last_position = input.position();
                 ctry!(input.reset(before).consumed());
 
@@ -443,16 +443,16 @@ impl<F, P> Recognize<F, P> {
                     match input.uncons() {
                         Ok(elem) => elements.extend(Some(elem)),
                         Err(err) => {
-                            return EmptyErr(
+                            return PeekErr(
                                 <Input as StreamOnce>::Error::from_error(input.position(), err)
                                     .into(),
                             );
                         }
                     }
                 }
-                EmptyOk(mem::replace(elements, F::default()))
+                PeekOk(mem::replace(elements, F::default()))
             }
-            ConsumedOk(_) => {
+            CommitOk(_) => {
                 let last_position = input.position();
                 ctry!(input.reset(before).consumed());
 
@@ -460,16 +460,16 @@ impl<F, P> Recognize<F, P> {
                     match input.uncons() {
                         Ok(elem) => elements.extend(Some(elem)),
                         Err(err) => {
-                            return ConsumedErr(<Input as StreamOnce>::Error::from_error(
+                            return CommitErr(<Input as StreamOnce>::Error::from_error(
                                 input.position(),
                                 err,
                             ));
                         }
                     }
                 }
-                ConsumedOk(mem::replace(elements, F::default()))
+                CommitOk(mem::replace(elements, F::default()))
             }
-            ConsumedErr(err) => {
+            CommitErr(err) => {
                 let last_position = input.position();
                 ctry!(input.reset(before).consumed());
 
@@ -477,16 +477,16 @@ impl<F, P> Recognize<F, P> {
                     match input.uncons() {
                         Ok(elem) => elements.extend(Some(elem)),
                         Err(err) => {
-                            return ConsumedErr(<Input as StreamOnce>::Error::from_error(
+                            return CommitErr(<Input as StreamOnce>::Error::from_error(
                                 input.position(),
                                 err,
                             ));
                         }
                     }
                 }
-                ConsumedErr(err)
+                CommitErr(err)
             }
-            EmptyErr(err) => EmptyErr(err),
+            PeekErr(err) => PeekErr(err),
         }
     }
 }
@@ -750,7 +750,7 @@ where
             self.0.parse_mode(mode, input, child_state)
         };
 
-        if let ConsumedErr(_) = result {
+        if let CommitErr(_) = result {
             if state.0.is_none() {
                 // FIXME Make None unreachable for LLVM
                 state.0 = Some(Box::new(new_child_state.unwrap()));
@@ -850,7 +850,7 @@ where
             self.0.parse_mode(mode, input, child_state)
         };
 
-        if let ConsumedErr(_) = result {
+        if let CommitErr(_) = result {
             if state.0.is_none() {
                 // FIXME Make None unreachable for LLVM
                 state.0 = Some(Box::new(new_child_state.unwrap()));
@@ -1330,7 +1330,7 @@ where
     {
         let mut input_inner = match self.converter.convert(input) {
             Ok(x) => x,
-            Err(err) => return EmptyErr(err.into()),
+            Err(err) => return PeekErr(err.into()),
         };
         self.parser
             .parse_mode(mode, &mut input_inner, state)

--- a/src/parser/error.rs
+++ b/src/parser/error.rs
@@ -24,7 +24,7 @@ where
     type PartialState = ();
     #[inline]
     fn parse_lazy(&mut self, input: &mut Input) -> ParseResult<T, <Input as StreamOnce>::Error> {
-        EmptyErr(<Input as StreamOnce>::Error::empty(input.position()).into())
+        PeekErr(<Input as StreamOnce>::Error::empty(input.position()).into())
     }
     fn add_error(&mut self, errors: &mut Tracked<<Input as StreamOnce>::Error>) {
         errors.error.add(StreamError::unexpected(&self.0));
@@ -115,17 +115,17 @@ where
         M: ParseMode,
     {
         match self.0.parse_mode(mode, input, state) {
-            ConsumedOk(x) => ConsumedOk(x),
-            EmptyOk(x) => EmptyOk(x),
+            CommitOk(x) => CommitOk(x),
+            PeekOk(x) => PeekOk(x),
 
             // The message should always be added even if some input was consumed before failing
-            ConsumedErr(mut err) => {
+            CommitErr(mut err) => {
                 err.add_message(&self.1);
-                ConsumedErr(err)
+                CommitErr(err)
             }
 
             // The message will be added in `add_error`
-            EmptyErr(err) => EmptyErr(err),
+            PeekErr(err) => PeekErr(err),
         }
     }
 

--- a/src/parser/function.rs
+++ b/src/parser/function.rs
@@ -31,7 +31,7 @@ pub struct FnParser<Input, F>(F, PhantomData<fn(Input) -> Input>);
 /// extern crate combine;
 /// # use combine::*;
 /// # use combine::parser::char::digit;
-/// # use combine::error::{Consumed, StreamError};
+/// # use combine::error::{Commit, StreamError};
 /// # use combine::stream::easy;
 /// # fn main() {
 /// let mut even_digit = parser(|input| {
@@ -49,7 +49,7 @@ pub struct FnParser<Input, F>(F, PhantomData<fn(Input) -> Input>);
 ///             position,
 ///             StreamError::expected("even number")
 ///         );
-///         Err(Consumed::Empty(errors.into()))
+///         Err(Commit::Peek(errors.into()))
 ///     }
 /// });
 /// let result = even_digit

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -139,7 +139,7 @@ pub trait Parser<Input: Stream> {
         let before = input.checkpoint();
         let mut state = Default::default();
         let mut result = self.parse_first(input, &mut state);
-        if let ParseResult::EmptyErr(ref mut error) = result {
+        if let ParseResult::PeekErr(ref mut error) = result {
             ctry!(input.reset(before.clone()).consumed());
             if let Ok(t) = input.uncons() {
                 ctry!(input.reset(before).consumed());
@@ -155,7 +155,7 @@ pub trait Parser<Input: Stream> {
     /// Specialized version of [`parse_stream`] which permits error value creation to be
     /// skipped in the common case.
     ///
-    /// When this parser returns `EmptyErr`, this method is allowed to return an empty
+    /// When this parser returns `PeekErr`, this method is allowed to return an empty
     /// [`Error`]. The error value that would have been returned can instead be obtained by
     /// calling [`add_error`]. This allows a parent parser such as `choice` to skip the creation of
     /// an unnecessary error value, if an alternative parser succeeds.
@@ -180,7 +180,7 @@ pub trait Parser<Input: Stream> {
             // resume itself
             let before = input.checkpoint();
             let result = self.parse_first(input, &mut Default::default());
-            if let ConsumedErr(_) = result {
+            if let CommitErr(_) = result {
                 ctry!(input.reset(before).consumed());
             }
             result
@@ -190,7 +190,7 @@ pub trait Parser<Input: Stream> {
     }
 
     /// Adds the first error that would normally be returned by this parser if it failed with an
-    /// `EmptyErr` result.
+    /// `PeekErr` result.
     ///
     /// See [`parse_lazy`] for details.
     ///
@@ -206,7 +206,7 @@ pub trait Parser<Input: Stream> {
     ) -> ParseResult<Self::Output, <Input as StreamOnce>::Error> {
         let before = input.checkpoint();
         let mut result = self.parse_partial(input, state);
-        if let ParseResult::EmptyErr(ref mut error) = result {
+        if let ParseResult::PeekErr(ref mut error) = result {
             ctry!(input.reset(before.clone()).consumed());
             if let Ok(t) = input.uncons() {
                 ctry!(input.reset(before).consumed());
@@ -1048,7 +1048,7 @@ pub trait ParseMode: Copy {
     {
         let before = input.checkpoint();
         let mut result = parser.parse_mode_impl(self, input, state);
-        if let ParseResult::EmptyErr(ref mut error) = result {
+        if let ParseResult::PeekErr(ref mut error) = result {
             ctry!(input.reset(before.clone()).consumed());
             if let Ok(t) = input.uncons() {
                 ctry!(input.reset(before).consumed());

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -125,11 +125,11 @@ pub trait Parser<Input: Stream> {
     /// Parses using the stream `input` by calling [`Stream::uncons`] one or more times.
     ///
     /// Semantically equivalent to [`parse_stream`], except this method returns a flattened result
-    /// type, combining `Result` and [`Consumed`] into a single [`ParseResult`].
+    /// type, combining `Result` and [`Commit`] into a single [`ParseResult`].
     ///
     /// [`Stream::uncons`]: ../trait.StreamOnce.html#tymethod.uncons
     /// [`parse_stream`]: trait.Parser.html#method.parse_stream
-    /// [`Consumed`]: ../error/enum.Consumed.html
+    /// [`Commit`]: ../error/enum.Commit.html
     /// [`ParseResult`]: ../error/enum.ParseResult.html
     #[inline]
     fn parse_stream(
@@ -330,7 +330,7 @@ pub trait Parser<Input: Stream> {
     /// ```
     /// # extern crate combine;
     /// # use combine::*;
-    /// # use combine::error::Consumed;
+    /// # use combine::error::Commit;
     /// # use combine::parser::char::{digit, letter};
     /// fn test(input: &mut &'static str) -> StdParseResult<(char, char), &'static str> {
     ///     let mut p = digit();
@@ -343,7 +343,7 @@ pub trait Parser<Input: Stream> {
     ///     let mut input = "1a23";
     ///     assert_eq!(
     ///         test(&mut input).map(|(t, c)| (t, c.map(|_| input))),
-    ///         Ok((('1', '2'), Consumed::Consumed("3")))
+    ///         Ok((('1', '2'), Commit::Commit("3")))
     ///     );
     /// }
     /// ```
@@ -424,8 +424,8 @@ pub trait Parser<Input: Stream> {
         (self, p)
     }
 
-    /// Returns a parser which attempts to parse using `self`. If `self` fails without consuming
-    /// any input it tries to consume the same input using `p`.
+    /// Returns a parser which attempts to parse using `self`. If `self` fails without committing
+    /// it tries to consume the same input using `p`.
     ///
     /// If you are looking to chain 3 or more parsers using `or` you may consider using the
     /// [`choice!`] macro instead, which can be clearer and may result in a faster parser.
@@ -474,7 +474,7 @@ pub trait Parser<Input: Stream> {
     /// # extern crate combine;
     /// # use combine::*;
     /// # use combine::parser::char::digit;
-    /// # use combine::error::Consumed;
+    /// # use combine::error::Commit;
     /// # use combine::stream::easy;
     /// # fn main() {
     /// let result = digit()
@@ -513,7 +513,7 @@ pub trait Parser<Input: Stream> {
     /// # extern crate combine;
     /// # use combine::*;
     /// # use combine::parser::char::digit;
-    /// # use combine::error::Consumed;
+    /// # use combine::error::Commit;
     /// # use combine::stream::easy;
     /// # fn main() {
     /// let result = digit()

--- a/src/parser/regex.rs
+++ b/src/parser/regex.rs
@@ -234,9 +234,9 @@ where
         input: &mut Input,
     ) -> ParseResult<Self::Output, <Input as StreamOnce>::Error> {
         if self.0.is_match(input.range()) {
-            EmptyOk(input.range())
+            PeekOk(input.range())
         } else {
-            EmptyErr(Input::Error::empty(input.position()).into())
+            PeekErr(Input::Error::empty(input.position()).into())
         }
     }
     fn add_error(&mut self, error: &mut Tracked<<Input as StreamOnce>::Error>) {
@@ -293,7 +293,7 @@ where
         let (end, First(value)) = self.0.find_iter(input.range());
         match value {
             Some(value) => take(end).parse_lazy(input).map(|_| value),
-            None => EmptyErr(Input::Error::empty(input.position()).into()),
+            None => PeekErr(Input::Error::empty(input.position()).into()),
         }
     }
     fn add_error(&mut self, error: &mut Tracked<<Input as StreamOnce>::Error>) {
@@ -413,7 +413,7 @@ where
         let (end, First(value)) = self.0.captures(input.range());
         match value {
             Some(value) => take(end).parse_lazy(input).map(|_| value),
-            None => EmptyErr(Input::Error::empty(input.position()).into()),
+            None => PeekErr(Input::Error::empty(input.position()).into()),
         }
     }
     fn add_error(&mut self, error: &mut Tracked<<Input as StreamOnce>::Error>) {


### PR DESCRIPTION
This more accurately explains what these cases mean. Either a parser has
committed to its parse, so if it fails it should not attempt other
parsers or it just `peek`ed on its input and it is ok to attempt another
one.

`Consumed` and `Empty` were only accurate in what they did in simple
cases but as soon as `attempt` or a partial input failed they would not
be true any more. Also this is just a better explanation of how other
parsers should act when a parser returns one of these.

BREAKING CHANGE

Rename any use of `Consumed` to `Commit` and `Empty` to `Peek`

