### PR TITLE
fix char module name in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ An implementation of parser combinators for Rust, inspired by the Haskell librar
 ```rust
 extern crate combine;
 use combine::{many1, Parser, sep_by};
-use combine::char::{letter, space};
+use combine::parser::char::{letter, space};
 
 // Construct a parser that parses *many* (and at least *1) *letter*s
 let word = many1(letter());


### PR DESCRIPTION
Copy/pasting the example from the readme yields this error:

```
error[E0432]: unresolved import `combine::char`
 --> src/main.rs:3:14
  |
3 | use combine::char::{letter, space};
  |              ^^^^ could not find `char` in `combine`
```
