### PR TITLE
Fix clippy for good

### DIFF
--- a/examples/async.rs
+++ b/examples/async.rs
@@ -32,8 +32,8 @@ pub struct LanguageServerDecoder {
     content_length_parses: Rc<Cell<i32>>,
 }
 
-impl LanguageServerDecoder {
-    pub fn new() -> LanguageServerDecoder {
+impl Default for LanguageServerDecoder {
+    fn default() -> Self {
         LanguageServerDecoder {
             state: Default::default(),
             content_length_parses: Rc::new(Cell::new(0)),
@@ -161,12 +161,12 @@ async fn main() {
         PartialOp::Limited(2),
         PartialOp::Limited(3),
     ];
-    let ref mut reader = Cursor::new(input.as_bytes());
+    let reader = &mut Cursor::new(input.as_bytes());
     // Using the `partial_io` crate we emulate the partial reads that would happen when reading
     // asynchronously from an io device.
     let partial_reader = PartialAsyncRead::new(reader, seq);
 
-    let decoder = LanguageServerDecoder::new();
+    let decoder = LanguageServerDecoder::default();
     let content_length_parses = decoder.content_length_parses.clone();
 
     let result = FramedRead::new(partial_reader, decoder).try_collect().await;

--- a/examples/date.rs
+++ b/examples/date.rs
@@ -158,10 +158,7 @@ where
     Input: Stream<Token = char>,
     Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 {
-    (date(), char('T'), time()).map(|(date, _, time)| DateTime {
-        date,
-        time,
-    })
+    (date(), char('T'), time()).map(|(date, _, time)| DateTime { date, time })
 }
 
 #[test]

--- a/examples/date.rs
+++ b/examples/date.rs
@@ -119,8 +119,8 @@ where
             // Its ok to just unwrap since we only parsed digits
             Date {
                 year: year.parse().unwrap(),
-                month: month,
-                day: day,
+                month,
+                day,
             }
         })
 }
@@ -143,10 +143,10 @@ where
         .map(|(hour, _, minute, _, second, time_zone)| {
             // Its ok to just unwrap since we only parsed digits
             Time {
-                hour: hour,
-                minute: minute,
-                second: second,
-                time_zone: time_zone,
+                hour,
+                minute,
+                second,
+                time_zone,
             }
         })
 }
@@ -159,8 +159,8 @@ where
     Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 {
     (date(), char('T'), time()).map(|(date, _, time)| DateTime {
-        date: date,
-        time: time,
+        date,
+        time,
     })
 }
 

--- a/examples/ini.rs
+++ b/examples/ini.rs
@@ -92,10 +92,8 @@ where
     Input: Stream<Token = char>,
     Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 {
-    (whitespace(), properties(), many(section())).map(|(_, global, sections)| Ini {
-        global,
-        sections,
-    })
+    (whitespace(), properties(), many(section()))
+        .map(|(_, global, sections)| Ini { global, sections })
 }
 
 #[test]

--- a/examples/ini.rs
+++ b/examples/ini.rs
@@ -93,8 +93,8 @@ where
     Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 {
     (whitespace(), properties(), many(section())).map(|(_, global, sections)| Ini {
-        global: global,
-        sections: sections,
+        global,
+        sections,
     })
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,7 +189,8 @@
 #![allow(
     clippy::inline_always,
     clippy::type_complexity,
-    clippy::too_many_arguments
+    clippy::too_many_arguments,
+    clippy::match_like_matches_macro
 )]
 #![cfg_attr(not(feature = "std"), no_std)]
 


### PR DESCRIPTION
* allow not using 'matches!()' for now due to constraint to Rust 1.40
* run with `cargo clippy --examples` to catch more issues and fix them
