### PR TITLE
fix doc(cfg) annotations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ edition = "2018"
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
 
 [lib]
 name = "combine"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,6 +193,7 @@
     clippy::match_like_matches_macro
 )]
 #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[doc(inline)]
 pub use crate::error::{ParseError, ParseResult, StdParseResult};

--- a/src/parser/combinator.rs
+++ b/src/parser/combinator.rs
@@ -712,10 +712,12 @@ where
 }
 
 #[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 #[derive(Default)]
 pub struct AnyPartialState(Option<Box<dyn std::any::Any>>);
 
 #[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub struct AnyPartialStateParser<P>(P);
 
 #[cfg(feature = "std")]
@@ -802,6 +804,7 @@ where
 /// # }
 /// ```
 #[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub fn any_partial_state<Input, P>(p: P) -> AnyPartialStateParser<P>
 where
     Input: Stream,
@@ -812,10 +815,12 @@ where
 }
 
 #[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 #[derive(Default)]
 pub struct AnySendPartialState(Option<Box<dyn std::any::Any + Send>>);
 
 #[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub struct AnySendPartialStateParser<P>(P);
 
 #[cfg(feature = "std")]
@@ -902,6 +907,7 @@ where
 /// # }
 /// ```
 #[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub fn any_send_partial_state<Input, P>(p: P) -> AnySendPartialStateParser<P>
 where
     Input: Stream,
@@ -912,10 +918,12 @@ where
 }
 
 #[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 #[derive(Default)]
 pub struct AnySendSyncPartialState(Option<Box<dyn std::any::Any + Send + Sync>>);
 
 #[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub struct AnySendSyncPartialStateParser<P>(P);
 
 #[cfg(feature = "std")]
@@ -1001,6 +1009,7 @@ where
 /// # }
 /// ```
 #[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub fn any_send_sync_partial_state<Input, P>(p: P) -> AnySendSyncPartialStateParser<P>
 where
     Input: Stream,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -840,6 +840,7 @@ pub trait Parser<Input: Stream> {
     /// # }
     /// ```
     #[cfg(feature = "std")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     fn boxed<'a>(
         self,
     ) -> Box<dyn Parser<Input, Output = Self::Output, PartialState = Self::PartialState> + 'a>
@@ -920,6 +921,7 @@ pub trait Parser<Input: Stream> {
 
 /// Provides the `easy_parse` method which provides good error messages by default
 #[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub trait EasyParser<Input: Stream>: Parser<crate::easy::Stream<Input>>
 where
     Input::Token: PartialEq,
@@ -967,7 +969,6 @@ where
     /// ```
     ///
     /// [`ParseError`]: struct.ParseError.html
-    #[cfg(feature = "std")]
     fn easy_parse(
         &mut self,
         input: Input,

--- a/src/stream/buf_reader.rs
+++ b/src/stream/buf_reader.rs
@@ -133,13 +133,13 @@ pub trait CombineAsyncRead<R>: CombineBuffer<R> {
         Self: Sized;
 }
 
-#[doc(hidden)]
 #[cfg(feature = "futures-03")]
 pin_project_lite::pin_project! {
-pub struct ExtendBuf<'a, C, R> {
-    buffer: &'a mut C,
-    read: Pin<&'a mut R>
-}
+    #[doc(hidden)]
+    pub struct ExtendBuf<'a, C, R> {
+        buffer: &'a mut C,
+        read: Pin<&'a mut R>
+    }
 }
 
 #[cfg(feature = "futures-03")]

--- a/src/stream/decoder.rs
+++ b/src/stream/decoder.rs
@@ -46,7 +46,6 @@ impl<E: fmt::Display, P: fmt::Display> fmt::Display for Error<E, P> {
     }
 }
 
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 #[derive(Default)]
 /// Used together with the `decode!` macro
 pub struct Decoder<S, P, C = Buffer> {
@@ -56,7 +55,6 @@ pub struct Decoder<S, P, C = Buffer> {
     end_of_input: bool,
 }
 
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl<S, P> Decoder<S, P, Buffer>
 where
     P: Default,

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -50,16 +50,19 @@ macro_rules! clone_resetable {
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub mod buf_reader;
-#[cfg(feature = "std")]
 /// Stream wrapper which provides a `ResetStream` impl for `StreamOnce` impls which do not have
 /// one.
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub mod buffered;
 #[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub mod easy;
 /// Stream wrapper which provides more detailed position information.
 pub mod position;
 /// Stream wrapper allowing `std::io::Read` to be used
 #[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub mod read;
 /// Stream wrapper allowing custom state to be used.
 pub mod state;


### PR DESCRIPTION
This crate have used a bunch of `#[cfg_attr(docsrs, doc(cfg(feature = "...")))]` annotations,
but it had 3 problems:
- Not all `cfg`-ed had one
- The crate didn't enable `feature(doc_cfg)` which made it's docs unbuildable with `--cfg docsrs` (this also caused problems when building docs of crates which depend on this crate)
- docs.rs setting were missing `--cfg docsrs`, so it didn't include `supported on crate feature="..." only` things

This PR fixes those problems.
