### PR TITLE
Fix and add some document links

### DIFF
--- a/src/parser/byte.rs
+++ b/src/parser/byte.rs
@@ -257,7 +257,7 @@ parser! {
 /// # }
 /// ```
 ///
-/// [`RangeStream`]: ../stream/trait.RangeStream.html
+/// [`RangeStream`]: super::super::stream::RangeStream
 /// [`range`]: ../range/fn.range.html
 pub fn bytes['a, 'b, Input](s: &'static [u8])(Input) -> &'a [u8]
 where [
@@ -287,7 +287,7 @@ parser! {
 /// # }
 /// ```
 ///
-/// [`RangeStream`]: ../stream/trait.RangeStream.html
+/// [`RangeStream`]: super::super::stream::RangeStream
 /// [`range`]: ../range/fn.range.html
 pub fn bytes_cmp['a, 'b, C, Input](s: &'static [u8], cmp: C)(Input) -> &'a [u8]
 where [

--- a/src/parser/byte.rs
+++ b/src/parser/byte.rs
@@ -258,7 +258,7 @@ parser! {
 /// ```
 ///
 /// [`RangeStream`]: super::super::stream::RangeStream
-/// [`range`]: ../range/fn.range.html
+/// [`range`]: super::range::range
 pub fn bytes['a, 'b, Input](s: &'static [u8])(Input) -> &'a [u8]
 where [
     Input: Stream<Token = u8, Range = &'b [u8]>,
@@ -288,7 +288,7 @@ parser! {
 /// ```
 ///
 /// [`RangeStream`]: super::super::stream::RangeStream
-/// [`range`]: ../range/fn.range.html
+/// [`range`]: super::range::range
 pub fn bytes_cmp['a, 'b, C, Input](s: &'static [u8], cmp: C)(Input) -> &'a [u8]
 where [
     C: FnMut(u8, u8) -> bool,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,6 +1,6 @@
 //! A collection of both concrete parsers as well as parser combinators.
 //!
-//! Implements the `Parser` trait which is the core of `combine` and contains the submodules
+//! Implements the [`Parser`] trait which is the core of `combine` and contains the submodules
 //! implementing all combine parsers.
 
 use crate::{
@@ -94,11 +94,11 @@ pub trait Parser<Input: Stream> {
     ///
     /// This is the most straightforward entry point to a parser. Since it does not decorate the
     /// input in any way you may find the error messages a hard to read. If that is the case you
-    /// may want to try wrapping your input with an [`easy::Stream`][] or call [`easy_parse`][]
+    /// may want to try wrapping your input with an [`easy::Stream`] or call [`easy_parse`]
     /// instead.
     ///
-    /// [`easy::Stream`]: ../easy/struct.Stream.html
-    /// [`easy_parse`]: trait.Parser.html#method.easy_parse
+    /// [`easy::Stream`]: super::easy::Stream
+    /// [`easy_parse`]: super::parser::EasyParser::easy_parse
     fn parse(
         &mut self,
         mut input: Input,
@@ -130,10 +130,10 @@ pub trait Parser<Input: Stream> {
     /// Semantically equivalent to [`parse_stream`], except this method returns a flattened result
     /// type, combining `Result` and [`Commit`] into a single [`ParseResult`].
     ///
-    /// [`Stream::uncons`]: ../trait.StreamOnce.html#tymethod.uncons
+    /// [`Stream::uncons`]: super::stream::StreamOnce::uncons
     /// [`parse_stream`]: trait.Parser.html#method.parse_stream
-    /// [`Commit`]: ../error/enum.Commit.html
-    /// [`ParseResult`]: ../error/enum.ParseResult.html
+    /// [`Commit`]: super::error::Commit
+    /// [`ParseResult`]: super::error::ParseResult
     #[inline]
     fn parse_stream(
         &mut self,
@@ -167,9 +167,9 @@ pub trait Parser<Input: Stream> {
     /// encountered before consuming input. The default implementation always returns all errors,
     /// with [`add_error`] being a no-op.
     ///
-    /// [`Stream::uncons`]: ../trait.StreamOnce.html#tymethod.uncons
+    /// [`Stream::uncons`]: super::stream::StreamOnce::uncons
     /// [`parse_stream`]: trait.Parser.html#method.parse_stream
-    /// [`Error`]: ../stream/trait.StreamOnce.html#associatedtype.Error
+    /// [`Error`]: super::stream::StreamOnce::Error
     /// [`add_error`]: trait.Parser.html#method.add_error
     #[inline]
     fn parse_lazy(
@@ -452,7 +452,7 @@ pub trait Parser<Input: Stream> {
     /// # }
     /// ```
     ///
-    /// [`choice!`]: ../macro.choice.html
+    /// [`choice!`]: super::choice!
     fn or<P2>(self, p: P2) -> Or<Self, P2>
     where
         Self: Sized,
@@ -779,7 +779,7 @@ pub trait Parser<Input: Stream> {
     /// # }
     /// ```
     ///
-    /// [`many`]: ../combinator/fn.many.html
+    /// [`many`]: repeat::many
     fn iter(self, input: &mut Input) -> Iter<'_, Input, Self, Self::PartialState, FirstMode>
     where
         Self: Parser<Input> + Sized,
@@ -809,7 +809,7 @@ pub trait Parser<Input: Stream> {
     /// # }
     /// ```
     ///
-    /// [`many`]: ../combinator/fn.many.html
+    /// [`many`]: repeat::many
     fn partial_iter<'a, 's, M>(
         self,
         mode: M,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -465,9 +465,9 @@ pub trait Parser<Input: Stream> {
     /// the rest of the input.
     ///
     /// Since the parser returned from `f` must have a single type it can be useful to use the
-    /// `left` and `right` methods to merge parsers of differing types into one.
+    /// [`left`](Parser::left) and [`right`](Parser::right) methods to merge parsers of differing types into one.
     ///
-    /// If you are using partial parsing you may want to use `partial_then` instead.
+    /// If you are using partial parsing you may want to use [`then_partial`](Parser::then_partial) instead.
     ///
     /// ```
     /// # #![cfg(feature = "std")]
@@ -499,14 +499,14 @@ pub trait Parser<Input: Stream> {
         then(self, f)
     }
 
-    /// Variant of `then` which parses using `self` and then passes the value to `f` as a `&mut` reference.
+    /// Variant of [`then`](Parser::then) which parses using `self` and then passes the value to `f` as a `&mut` reference.
     ///
     /// Useful when doing partial parsing since it does not need to store the parser returned by
     /// `f` in the partial state. Instead it will call `f` each to request a new parser each time
     /// parsing resumes and that parser is needed.
     ///
     /// Since the parser returned from `f` must have a single type it can be useful to use the
-    /// `left` and `right` methods to merge parsers of differing types into one.
+    /// [`left`](Parser::left) and [`right`](Parser::right) methods to merge parsers of differing types into one.
     ///
     /// ```
     /// # #![cfg(feature = "std")]
@@ -853,7 +853,7 @@ pub trait Parser<Input: Stream> {
         Box::new(self)
     }
 
-    /// Wraps the parser into the `Either` enum which allows combinators such as `then` to return
+    /// Wraps the parser into the [`Either`](crate::parser::combinator::Either) enum which allows combinators such as [`then`](Parser::then) to return
     /// multiple different parser types (merging them to one)
     ///
     /// ```
@@ -887,7 +887,7 @@ pub trait Parser<Input: Stream> {
         Either::Left(self)
     }
 
-    /// Wraps the parser into the `Either` enum which allows combinators such as `then` to return
+    /// Wraps the parser into the [`Either`](crate::parser::combinator::Either) enum which allows combinators such as [`then`](Parser::then) to return
     /// multiple different parser types (merging them to one)
     ///
     /// ```

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -131,7 +131,7 @@ pub trait Parser<Input: Stream> {
     /// type, combining `Result` and [`Commit`] into a single [`ParseResult`].
     ///
     /// [`Stream::uncons`]: super::stream::StreamOnce::uncons
-    /// [`parse_stream`]: trait.Parser.html#method.parse_stream
+    /// [`parse_stream`]: Parser::parse_stream
     /// [`Commit`]: super::error::Commit
     /// [`ParseResult`]: super::error::ParseResult
     #[inline]
@@ -168,7 +168,7 @@ pub trait Parser<Input: Stream> {
     /// with [`add_error`] being a no-op.
     ///
     /// [`Stream::uncons`]: super::stream::StreamOnce::uncons
-    /// [`parse_stream`]: trait.Parser.html#method.parse_stream
+    /// [`parse_stream`]: Parser::parse_stream
     /// [`Error`]: super::stream::StreamOnce::Error
     /// [`add_error`]: trait.Parser.html#method.add_error
     #[inline]

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -853,7 +853,7 @@ pub trait Parser<Input: Stream> {
         Box::new(self)
     }
 
-    /// Wraps the parser into the [`Either`](crate::parser::combinator::Either) enum which allows combinators such as [`then`](Parser::then) to return
+    /// Wraps the parser into the [`Either`](combinator::Either) enum which allows combinators such as [`then`](Parser::then) to return
     /// multiple different parser types (merging them to one)
     ///
     /// ```
@@ -887,7 +887,7 @@ pub trait Parser<Input: Stream> {
         Either::Left(self)
     }
 
-    /// Wraps the parser into the [`Either`](crate::parser::combinator::Either) enum which allows combinators such as [`then`](Parser::then) to return
+    /// Wraps the parser into the [`Either`](combinator::Either) enum which allows combinators such as [`then`](Parser::then) to return
     /// multiple different parser types (merging them to one)
     ///
     /// ```

--- a/src/parser/range.rs
+++ b/src/parser/range.rs
@@ -202,9 +202,9 @@ where
 /// Zero-copy parser which returns a pair: (committed input range, parsed value).
 ///
 ///
-/// [`combinator::recognize_with_value`][] is a non-`RangeStream` alternative.
+/// [`combinator::recognize_with_value`] is a non-`RangeStream` alternative.
 ///
-/// [`combinator::recognize_with_value`]: ../../parser/combinator/fn.recognize_with_value.html
+/// [`combinator::recognize_with_value`]: recognize_with_value
 /// ```
 /// # extern crate combine;
 /// # use combine::parser::range::recognize_with_value;
@@ -234,9 +234,9 @@ where
 /// Zero-copy parser which reads a range of length `i.len()` and succeeds if `i` is equal to that
 /// range.
 ///
-/// [`tokens2`][] is a non-`RangeStream` alternative.
+/// [`tokens`] is a non-`RangeStream` alternative.
 ///
-/// [`tokens2`]: ../../parser/token/fn.tokens2.html
+/// [`tokens`]: super::token::tokens
 /// ```
 /// # extern crate combine;
 /// # use combine::parser::range::range;

--- a/src/stream/decoder.rs
+++ b/src/stream/decoder.rs
@@ -60,16 +60,16 @@ where
     P: Default,
     S: Default,
 {
-    /// Constructs a new `Decoder` with an internal buffer. Allows any `AsyncRead/Read` instance to
+    /// Constructs a new [`Decoder`] with an internal buffer. Allows any `AsyncRead/Read` instance to
     /// be used when decoding but there may be data left in the internal buffer after decoding
-    /// (accessible with `Decoder::buffer`
+    /// (accessible with [`Decoder::buffer`])
     pub fn new() -> Self {
         Decoder::default()
     }
 
-    /// Constructs a new `Decoder` with an internal buffer. Allows any `AsyncRead/Read` instance to
+    /// Constructs a new [`Decoder`] with an internal buffer. Allows any `AsyncRead/Read` instance to
     /// be used when decoding but there may be data left in the internal buffer after decoding
-    /// (accessible with `Decoder::buffer`
+    /// (accessible with [`Decoder::buffer`])
     pub fn new_buffer() -> Self {
         Decoder::new()
     }
@@ -81,9 +81,9 @@ where
     S: Default,
 {
     /// Constructs a new `Decoder` without an internal buffer. Requires the read instance to be
-    /// wrapped with combine's [`BufReader`][] instance to
+    /// wrapped with combine's [`BufReader`] instance to
     ///
-    /// [`BufReader`]: stream/buf_reader/index.html
+    /// [`BufReader`]: super::buf_reader::BufReader
     pub fn new_bufferless() -> Self {
         Decoder::default()
     }

--- a/src/stream/easy.rs
+++ b/src/stream/easy.rs
@@ -2,7 +2,7 @@
 //!
 //! Unless you have specific constraints preventing you from using this error type (such as being
 //! a `no_std` environment) you probably want to use this stream type. It can easily be used
-//! through the [`Parser::easy_parse`][] method.
+//! through the [`EasyParser::easy_parse`] method.
 //!
 //! The provided `Errors` type is roughly the same as `ParseError` in combine 1.x and 2.x.
 //!
@@ -79,7 +79,7 @@
 //!
 //! ```
 //!
-//! [`Parser::easy_parse`]: ../../parser/trait.Parser.html#method.easy_parse
+//! [`EasyParser::easy_parse`]: super::super::parser::EasyParser::easy_parse
 use std::{error::Error as StdError, fmt};
 
 use crate::error::{Info as PrimitiveInfo, ParseResult, StreamError, Tracked};

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -1137,9 +1137,7 @@ where
 }
 
 /// Wrapper around iterators which allows them to be treated as a stream.
-/// Returned by [`from_iter`].
-///
-/// [`from_iter`]: fn.from_iter.html
+/// Returned by [`IteratorStream::new`].
 #[derive(Copy, Clone, Debug)]
 pub struct IteratorStream<Input>(Input);
 


### PR DESCRIPTION
This pull request mainly involves modifying links in some document comments.

* [cargo-doc](https://doc.rust-lang.org/cargo/commands/cargo-doc.html) and [cargo-deadlinks](https://crates.io/crates/cargo-deadlinks) are used for verification.
* Links are specified by name for the corrected parts. Reference: [The Rustdoc Book](https://doc.rust-lang.org/rustdoc/linking-to-items-by-name.html)

In addition, there are some corrections that I noticed while modifying the links.
The list them is below. If you have any suggestions, please let me know.

* `src/parser/mod.rs` >
  * `Parser`, `left`, `right` are enclosed in square brackets: I think that linking like this can be not only convenient but also safe since they can be verified that the path is correct.
  * `partial_then` to `then_partial`
* `src/parser/range.rs` > `tokens2` to `tokens`
* `src/stream/mod.rs` > `from_iter` to `IteratorSteram::new`

Also: #262 
(I haven't used tools like Travis CI or GitHub Actions yet. It would be nice to have validation like cargo-deadlinks done automatically in the future, but this change does not include the introduction of such tools.)