### PR TITLE
Update pin-project-lite to 0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,7 +278,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "partial-io",
- "pin-project-lite 0.1.11",
+ "pin-project-lite 0.2.0",
  "quick-error",
  "quickcheck",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ path = "src/lib.rs"
 [dependencies]
 regex = { version = "1", optional = true }
 memchr = { version = "2.2", default-features = false }
-pin-project-lite = { version = "0.1.11", optional = true }
+pin-project-lite = { version = "0.2", optional = true }
 # Future proofing so that tokio-0.3, tokio-0.1 etc can be supported
 tokio-02-dep = { version = "0.2.3", package = "tokio", features = ["io-util"], default-features = false, optional = true }
 tokio-03-dep = { version = "0.3", package = "tokio", default-features = false, optional = true }


### PR DESCRIPTION
tokio 0.2 depends on pin-project-lite 0.1, but everything else (futures-util, tokio 0.3, tokio 1.0) depends on pin-project-lite 0.2.