### PR TITLE
Removed unnecessary PartialEq constraint from some stream trait impls.

### DIFF
--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -702,7 +702,7 @@ where
 
 impl<'a, T> Positioned for &'a [T]
 where
-    T: Clone + PartialEq,
+    T: Clone,
 {
     #[inline]
     fn position(&self) -> Self::Position {
@@ -712,7 +712,7 @@ where
 
 impl<'a, T> StreamOnce for &'a [T]
 where
-    T: Clone + PartialEq,
+    T: Clone,
 {
     type Token = T;
     type Range = &'a [T];
@@ -1020,7 +1020,7 @@ impl<'a, T> Clone for SliceStream<'a, T> {
 
 impl<'a, T> Positioned for SliceStream<'a, T>
 where
-    T: PartialEq + 'a,
+    T: 'a,
 {
     #[inline]
     fn position(&self) -> Self::Position {
@@ -1030,7 +1030,7 @@ where
 
 impl<'a, T> StreamOnce for SliceStream<'a, T>
 where
-    T: PartialEq + 'a,
+    T: 'a,
 {
     type Token = &'a T;
     type Range = &'a [T];


### PR DESCRIPTION
Also added unit test to verify the impls work for types that don't implement PartialEq.

The specific use case I wanted to support was to run a parser on a SliceStream<proc_macro2::TokenTree>, but I believe the constraints I removed are just generally unnecessary.