### PR TITLE
feat: Add decode_tokio

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,9 @@ rust:
 - 1.40.0
 before_script:
 - |
-  pip install 'travis-cargo<0.2' --user &&
   export PATH=$HOME/.local/bin:$PATH
 script:
 - ./travis.sh
-- travis-cargo --only stable doc
 after_success: |
     if [[ "$TRAVIS_RUST_VERSION" == stable ]]; then
         bash <(curl https://raw.githubusercontent.com/xd009642/tarpaulin/master/travis-install.sh)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -884,7 +884,7 @@ mod std_tests {
     fn inner_error_consume() {
         let mut p = many::<Vec<_>, _, _>(between(char('['), char(']'), digit()));
         let result = p.easy_parse(position::Stream::new("[1][2][]"));
-        assert!(result.is_err(), format!("{:?}", result));
+        assert!(result.is_err(), "{:?}", result);
         let error = result.map(|x| format!("{:?}", x)).unwrap_err();
         assert_eq!(error.position, SourcePosition { line: 1, column: 8 });
     }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -7,7 +7,7 @@ use crate::{
     error::{
         ErrorInfo, ParseError,
         ParseResult::{self, *},
-        ResultExt, Token, Tracked,
+        ResultExt, StreamError, Token, Tracked,
     },
     parser::{
         combinator::{
@@ -18,7 +18,7 @@ use crate::{
         repeat::Iter,
         sequence::{then, then_partial, then_ref, Then, ThenPartial, ThenRef},
     },
-    stream::{Stream, StreamOnce},
+    stream::{Stream, StreamErrorFor, StreamOnce},
     ErrorOffset,
 };
 
@@ -147,6 +147,8 @@ pub trait Parser<Input: Stream> {
             if let Ok(t) = input.uncons() {
                 ctry!(input.reset(before).committed());
                 error.error.add_unexpected(Token(t));
+            } else {
+                error.error.add(StreamErrorFor::<Input>::end_of_input());
             }
             self.add_error(error);
         }
@@ -214,6 +216,8 @@ pub trait Parser<Input: Stream> {
             if let Ok(t) = input.uncons() {
                 ctry!(input.reset(before).committed());
                 error.error.add_unexpected(Token(t));
+            } else {
+                error.error.add(StreamErrorFor::<Input>::end_of_input());
             }
             self.add_error(error);
         }
@@ -1129,6 +1133,8 @@ pub trait ParseMode: Copy {
             if let Ok(t) = input.uncons() {
                 ctry!(input.reset(before).committed());
                 error.error.add_unexpected(Token(t));
+            } else {
+                error.error.add(StreamErrorFor::<Input>::end_of_input());
             }
             parser.add_error(error);
         }

--- a/src/parser/sequence.rs
+++ b/src/parser/sequence.rs
@@ -72,6 +72,7 @@ macro_rules! tuple_parser {
             $(
                 pub $id: $id,
             )*
+            #[allow(dead_code)]
             offset: u8,
             _marker: PhantomData <( $h, $( $id),* )>,
         }

--- a/travis.sh
+++ b/travis.sh
@@ -18,3 +18,7 @@ else
     cargo "$@" check --no-default-features --features tokio-02
     cargo "$@" check --no-default-features --features tokio-03
 fi
+
+if [[ "$TRAVIS_RUST_VERSION" == "stable" ]]; then
+    cargo doc
+fi


### PR DESCRIPTION
This works mostly the same as the regular `decode` function but it
can be plugged into both `decode` and `decode_eof` it will work as long
as the `eof` variant marks the input as non-partial.

Also ensures that unexpected end of inputs always get returned so that
we can detect them at the real end of input and return `None`.

The reqular `decode` function ended up still working as long as the
stream was always reported as partial as the parsers would endeavour
to return unexpected end of input in those cases.