### PR TITLE
fix: warning

### DIFF
--- a/src/parser/char.rs
+++ b/src/parser/char.rs
@@ -271,7 +271,6 @@ where
 /// # extern crate combine;
 /// # use combine::*;
 /// # use combine::parser::char::string_cmp;
-/// use std::ascii::AsciiExt;
 /// # fn main() {
 /// let result = string_cmp("rust", |l, r| l.eq_ignore_ascii_case(&r))
 ///     .parse("RusT")

--- a/src/stream/buf_reader.rs
+++ b/src/stream/buf_reader.rs
@@ -6,7 +6,14 @@ use std::io::{self, BufRead, Read};
     feature = "tokio-03",
     feature = "tokio"
 ))]
-use std::{mem::MaybeUninit, pin::Pin};
+use std::pin::Pin;
+
+#[cfg(any(
+    features = "futures-03",
+    feature = "tokio-02",
+    feature = "tokio-03"
+))]
+use std::mem::MaybeUninit;
 
 #[cfg(feature = "futures-core-03")]
 use std::task::{Context, Poll};


### PR DESCRIPTION
```
warning: use of deprecated trait `std::ascii::AsciiExt`: use inherent methods instead
 --> src/parser/char.rs:274:17
  |
5 | use std::ascii::AsciiExt;
  |                 ^^^^^^^^
  |
  = note: `#[warn(deprecated)]` on by default

warning: 1 warning emitted
```

```
warning: unused import: `mem::MaybeUninit`
 --> ~/.cargo/registry/src/mirrors.sjtug.sjtu.edu.cn-7a04d2510079875b/combine-4.6.1/src/stream/buf_reader.rs:9:11
  |
9 | use std::{mem::MaybeUninit, pin::Pin};
  |           ^^^^^^^^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default
```