### PR TITLE
perf: Handle restarts better in take_until_byte{,s,2,3}

### DIFF
--- a/src/parser/byte.rs
+++ b/src/parser/byte.rs
@@ -311,6 +311,7 @@ macro_rules! take_until {
         parser!{
             #[derive(Clone)]
             pub struct $type_name;
+            type PartialState = usize;
             $(#[$attr])*
             pub fn $func_name[Input]($($param : u8),*)(Input) -> Input::Range
                 where [
@@ -389,6 +390,7 @@ take_until! {
 }
 
 parser! {
+type PartialState = usize;
 /// Zero-copy parser which reads a range of 0 or more tokens until `needle` is found.
 ///
 /// If `a`, 'b' or `c` is not found, the parser will return an error.


### PR DESCRIPTION
These were ignoring the `PartialState` from `take_fn` which would cause
them to resume parsing from the start of the "haystack" on every
restart. Fixing the type signature will cause them to retain the `usize`
state that `take_fn` uses to skip ahead.

Fixes #327