### PR TITLE
fix(easy): Only back-quote parser tokens

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@
 //! use combine::parser::char::{digit, letter};
 //! const MSG: &'static str = r#"Parse error at line: 1, column: 1
 //! Unexpected `|`
-//! Expected `digit` or `letter`
+//! Expected digit or letter
 //! "#;
 //!
 //! fn main() {

--- a/src/stream/easy.rs
+++ b/src/stream/easy.rs
@@ -162,8 +162,8 @@ impl<T: PartialEq, R: PartialEq> PartialEq for Info<T, R> {
 impl<T: fmt::Display, R: fmt::Display> fmt::Display for Info<T, R> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
-            Info::Token(ref c) => write!(f, "{}", c),
-            Info::Range(ref c) => write!(f, "{}", c),
+            Info::Token(ref c) => write!(f, "`{}`", c),
+            Info::Range(ref c) => write!(f, "`{}`", c),
             Info::Owned(ref s) => write!(f, "{}", s),
             Info::Static(s) => write!(f, "{}", s),
         }
@@ -571,7 +571,7 @@ impl<T, R> Error<T, R> {
     /// let m = format!("{}", result.unwrap_err());
     /// let expected = r"Parse error at line: 2, column: 3
     /// Unexpected `,`
-    /// Expected `.`, `a` or `digit`
+    /// Expected `.`, `a` or digit
     /// ";
     /// assert_eq!(m, expected);
     /// # }
@@ -608,7 +608,7 @@ impl<T, R> Error<T, R> {
                 // Last expected message to be written
                 _ => " or",
             };
-            write!(f, "{} `{}`", s, message)?;
+            write!(f, "{} {}", s, message)?;
         }
         if expected_count != 0 {
             writeln!(f)?;
@@ -792,8 +792,8 @@ where
 impl<T: fmt::Display, R: fmt::Display> fmt::Display for Error<T, R> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
-            Error::Unexpected(ref c) => write!(f, "Unexpected `{}`", c),
-            Error::Expected(ref s) => write!(f, "Expected `{}`", s),
+            Error::Unexpected(ref c) => write!(f, "Unexpected {}", c),
+            Error::Expected(ref s) => write!(f, "Expected {}", s),
             Error::Message(ref msg) => msg.fmt(f),
             Error::Other(ref err) => err.fmt(f),
         }


### PR DESCRIPTION
When reviewing cargo moving fron `toml-rs` (hand-rolled parser) to
`toml_edit` (`combine`-based parser), one piece of feedback was about
only wanting tokens quoted and not textual descriptions.  It looks like
`combine` tracks all of the needed information and just a re-formatting
of the output is needed.

Fixes #334