### PR TITLE
Update feature-flag in documentation

### DIFF
--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -53,7 +53,7 @@ pub mod buf_reader;
 /// Stream wrapper which provides a `ResetStream` impl for `StreamOnce` impls which do not have
 /// one.
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub mod buffered;
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]


### PR DESCRIPTION
It appears that the feature flag has been changed from `std` to `alloc` some time in the past. However, the corresponding documentation attribute has been left unchanged.

Now one can (according to the docs) actually use `combine` with iterators on microcontrollers where you have an allocator available! 😉