### PR TITLE
Offset parser

### DIFF
--- a/src/stream/buf_reader.rs
+++ b/src/stream/buf_reader.rs
@@ -8,11 +8,7 @@ use std::io::{self, BufRead, Read};
 ))]
 use std::pin::Pin;
 
-#[cfg(any(
-    feature = "futures-03",
-    feature = "tokio-02",
-    feature = "tokio-03"
-))]
+#[cfg(any(feature = "futures-03", feature = "tokio-02", feature = "tokio-03"))]
 use std::mem::MaybeUninit;
 
 #[cfg(feature = "futures-core-03")]

--- a/src/stream/decoder.rs
+++ b/src/stream/decoder.rs
@@ -136,7 +136,7 @@ impl<S, P, C> Decoder<S, P, C> {
 
 impl<S, P, C> Decoder<S, P, C>
 where
-    C: ,
+    C:,
 {
     #[doc(hidden)]
     pub fn __before_parse<R>(&mut self, mut reader: R) -> io::Result<()>


### PR DESCRIPTION
Hello! Previously, I asked to make an `offset` function parsing data located by some offset. Finally, I've found time to do this one. But we should discuss the feature because `look_ahead(skip_count(count).with(parser))` does same thing as `offset`. Does the combine really need the new parser? If so then it closes #337.