### PR TITLE
Remove extraneous Input::Error trait bounds

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     strategy:
       matrix:
-        rust: [1.40.0, stable, beta, nightly]
+        rust: [1.51.0, stable, beta, nightly]
     env:
       CARGO_INCREMENTAL: 0 # Incremental compilation is slower and bloats the cache
       RUST_BACKTRACE: 1
@@ -32,14 +32,14 @@ jobs:
     - name: Build
       run: cargo build
 
-    - name: Check 1.40
-      if: ${{ matrix.rust == '1.40.0' }}
+    - name: Check 1.51
+      if: ${{ matrix.rust == '1.51.0' }}
       run: |
         cargo "$@" check
         cargo "$@" check --no-default-features
 
     - name: Run tests
-      if: ${{ matrix.rust != '1.40.0' }}
+      if: ${{ matrix.rust != '1.51.0' }}
       run: ./ci.sh
 
     - name: Check docs

--- a/benches/http.rs
+++ b/benches/http.rs
@@ -74,7 +74,6 @@ fn is_http_version(c: u8) -> bool {
 fn end_of_line<'a, Input>() -> impl Parser<Input, Output = u8>
 where
     Input: RangeStream<Token = u8, Range = &'a [u8]>,
-    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 {
     (token(b'\r'), token(b'\n')).map(|_| b'\r').or(token(b'\n'))
 }
@@ -82,7 +81,6 @@ where
 fn message_header<'a, Input>() -> impl Parser<Input, Output = Header<'a>>
 where
     Input: RangeStream<Token = u8, Range = &'a [u8]>,
-    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 {
     let message_header_line = (
         take_while1(is_horizontal_space),
@@ -103,7 +101,6 @@ type HttpRequest<'a> = (Request<'a>, Vec<Header<'a>>);
 fn parse_http_request<'a, Input>(input: Input) -> Result<(HttpRequest<'a>, Input), Input::Error>
 where
     Input: RangeStream<Token = u8, Range = &'a [u8]>,
-    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 {
     let http_version = range(&b"HTTP/"[..]).with(take_while1(is_http_version));
 
@@ -155,7 +152,7 @@ fn http_requests_large_cheap_error(b: &mut Bencher<'_>) {
 fn http_requests_bench<'a, Input>(b: &mut Bencher<'_>, buffer: Input)
 where
     Input: RangeStream<Token = u8, Range = &'a [u8]> + Clone,
-    Input::Error: ParseError<Input::Token, Input::Range, Input::Position> + fmt::Debug,
+    Input::Error: fmt::Debug,
 {
     b.iter(|| {
         let mut buf = black_box(buffer.clone());

--- a/benches/json.rs
+++ b/benches/json.rs
@@ -55,7 +55,6 @@ where
 fn integer<Input>() -> impl Parser<Input, Output = i64>
 where
     Input: Stream<Token = char>,
-    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 {
     lex(many1(digit()))
         .map(|s: String| {
@@ -71,7 +70,6 @@ where
 fn number<Input>() -> impl Parser<Input, Output = f64>
 where
     Input: Stream<Token = char>,
-    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 {
     let i = char('0').map(|_| 0.0).or(integer().map(|x| x as f64));
     let fractional = many(digit()).map(|digits: String| {
@@ -105,7 +103,6 @@ where
 fn json_char<Input>() -> impl Parser<Input, Output = char>
 where
     Input: Stream<Token = char>,
-    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 {
     parser(|input: &mut Input| {
         let (c, committed) = any().parse_lazy(input).into_result()?;
@@ -133,7 +130,6 @@ where
 fn json_string<Input>() -> impl Parser<Input, Output = String>
 where
     Input: Stream<Token = char>,
-    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 {
     between(char('"'), lex(char('"')), many(json_char())).expected("string")
 }
@@ -141,7 +137,6 @@ where
 fn object<Input>() -> impl Parser<Input, Output = Value>
 where
     Input: Stream<Token = char>,
-    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 {
     let field = (json_string(), lex(char(':')), json_value()).map(|t| (t.0, t.2));
     let fields = sep_by(field, lex(char(',')));
@@ -154,7 +149,6 @@ where
 fn json_value<Input>() -> impl Parser<Input, Output = Value>
 where
     Input: Stream<Token = char>,
-    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 {
     json_value_()
 }

--- a/examples/async.rs
+++ b/examples/async.rs
@@ -56,8 +56,6 @@ fn decode_parser<'a, Input>(
 ) -> impl Parser<Input, Output = Vec<u8>, PartialState = AnyPartialState> + 'a
 where
     Input: RangeStream<Token = u8, Range = &'a [u8]> + 'a,
-    // Necessary due to rust-lang/rust#24159
-    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 {
     let content_length = range(&b"Content-Length: "[..])
         .with(recognize(skip_many1(digit())).and_then(|digits: &[u8]| {

--- a/examples/date.rs
+++ b/examples/date.rs
@@ -9,7 +9,6 @@ use std::{
 
 use combine::{
     choice,
-    error::ParseError,
     many, optional,
     parser::char::{char, digit},
     stream::position,
@@ -63,8 +62,6 @@ pub struct DateTime {
 fn two_digits<Input>() -> impl Parser<Input, Output = i32>
 where
     Input: Stream<Token = char>,
-    // Necessary due to rust-lang/rust#24159
-    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 {
     (digit(), digit()).map(|(x, y): (char, char)| {
         let x = x.to_digit(10).expect("digit");
@@ -81,7 +78,6 @@ where
 fn time_zone<Input>() -> impl Parser<Input, Output = i32>
 where
     Input: Stream<Token = char>,
-    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 {
     let utc = char('Z').map(|_| 0);
     let offset = (
@@ -106,7 +102,6 @@ where
 fn date<Input>() -> impl Parser<Input, Output = Date>
 where
     Input: Stream<Token = char>,
-    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 {
     (
         many::<String, _, _>(digit()),
@@ -130,7 +125,6 @@ where
 fn time<Input>() -> impl Parser<Input, Output = Time>
 where
     Input: Stream<Token = char>,
-    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 {
     (
         two_digits(),
@@ -156,7 +150,6 @@ where
 fn date_time<Input>() -> impl Parser<Input, Output = DateTime>
 where
     Input: Stream<Token = char>,
-    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 {
     (date(), char('T'), time()).map(|(date, _, time)| DateTime { date, time })
 }

--- a/examples/ini.rs
+++ b/examples/ini.rs
@@ -41,8 +41,6 @@ pub struct Ini {
 fn property<Input>() -> impl Parser<Input, Output = (String, String)>
 where
     Input: Stream<Token = char>,
-    // Necessary due to rust-lang/rust#24159
-    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 {
     (
         many1(satisfy(|c| c != '=' && c != '[' && c != ';')),
@@ -56,7 +54,6 @@ where
 fn whitespace<Input>() -> impl Parser<Input>
 where
     Input: Stream<Token = char>,
-    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 {
     let comment = (token(';'), skip_many(satisfy(|c| c != '\n'))).map(|_| ());
     // Wrap the `spaces().or(comment)` in `skip_many` so that it skips alternating whitespace and
@@ -67,7 +64,6 @@ where
 fn properties<Input>() -> impl Parser<Input, Output = HashMap<String, String>>
 where
     Input: Stream<Token = char>,
-    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 {
     // After each property we skip any whitespace that followed it
     many(property().skip(whitespace()))
@@ -76,7 +72,6 @@ where
 fn section<Input>() -> impl Parser<Input, Output = (String, HashMap<String, String>)>
 where
     Input: Stream<Token = char>,
-    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 {
     (
         between(token('['), token(']'), many(satisfy(|c| c != ']'))),
@@ -90,7 +85,6 @@ where
 fn ini<Input>() -> impl Parser<Input, Output = Ini>
 where
     Input: Stream<Token = char>,
-    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 {
     (whitespace(), properties(), many(section()))
         .map(|(_, global, sections)| Ini { global, sections })

--- a/src/error.rs
+++ b/src/error.rs
@@ -296,7 +296,6 @@ impl<T> Commit<T> {
     /// //and " respectively
     /// fn char<Input>(input: &mut Input) -> StdParseResult<char, Input>
     ///     where Input: Stream<Token = char>,
-    ///           Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
     /// {
     ///     let (c, committed) = satisfy(|c| c != '"').parse_stream(input).into_result()?;
     ///     match c {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,8 +108,6 @@
 //! // `impl Parser` can be used to create reusable parsers with zero overhead
 //! fn expr_<Input>() -> impl Parser< Input, Output = Expr>
 //!     where Input: Stream<Token = char>,
-//!           // Necessary due to rust-lang/rust#24159
-//!           Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 //! {
 //!     let word = many1(letter());
 //!
@@ -259,7 +257,6 @@ pub use crate::parser::token::tokens_cmp;
 ///     fn integer[Input]()(Input) -> i32
 ///     where [
 ///         Input: Stream<Token = char>,
-///         Input::Error: ParseError<char, Input::Range, Input::Position>,
 ///         <Input::Error as ParseError<Input::Token, Input::Range, Input::Position>>::StreamError:
 ///             From<::std::num::ParseIntError>,
 ///     ]
@@ -283,7 +280,6 @@ pub use crate::parser::token::tokens_cmp;
 ///     pub fn integer_or_string[Input]()(Input) -> IntOrString
 ///     where [
 ///         Input: Stream<Token = char>,
-///         Input::Error: ParseError<char, Input::Range, Input::Position>,
 ///         <Input::Error as ParseError<Input::Token, Input::Range, Input::Position>>::StreamError:
 ///             From<::std::num::ParseIntError>,
 ///     ]
@@ -709,7 +705,6 @@ mod std_tests {
     fn integer<Input>(input: &mut Input) -> StdParseResult<i64, Input>
     where
         Input: Stream<Token = char>,
-        Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
     {
         let (s, input) = many1::<String, _, _>(digit())
             .expected("integer")
@@ -834,7 +829,6 @@ mod std_tests {
     fn term<Input>(input: &mut Input) -> StdParseResult<Expr, Input>
     where
         Input: Stream<Token = char>,
-        Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
     {
         fn times(l: Expr, r: Expr) -> Expr {
             Expr::Times(Box::new(l), Box::new(r))

--- a/src/parser/byte.rs
+++ b/src/parser/byte.rs
@@ -1,7 +1,7 @@
 //! Module containing parsers specialized on byte streams.
 
 use crate::{
-    error::{self, ParseError, ParseResult::*},
+    error::{self, ParseResult::*},
     parser::{
         combinator::no_partial,
         range::{take_fn, TakeRange},
@@ -24,7 +24,6 @@ use crate::{
 pub fn byte<Input>(c: u8) -> Token<Input>
 where
     Input: Stream<Token = u8>,
-    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 {
     token(c)
 }
@@ -51,7 +50,6 @@ macro_rules! byte_parser {
 pub fn digit<Input>() -> impl Parser<Input, Output = u8, PartialState = ()>
 where
     Input: Stream<Token = u8>,
-    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 {
     byte_parser!(digit, Digit, is_ascii_digit())
 }
@@ -69,7 +67,6 @@ where
 pub fn space<Input>() -> impl Parser<Input, Output = u8, PartialState = ()>
 where
     Input: Stream<Token = u8>,
-    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 {
     byte_parser!(space, Space, is_ascii_whitespace)
 }
@@ -87,7 +84,6 @@ where
 pub fn spaces<Input>() -> impl Parser<Input, Output = ()>
 where
     Input: Stream<Token = u8>,
-    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 {
     skip_many(space()).expected("whitespaces")
 }
@@ -103,7 +99,6 @@ where
 pub fn newline<Input>() -> impl Parser<Input, Output = u8, PartialState = ()>
 where
     Input: Stream<Token = u8>,
-    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 {
     satisfy(|ch: u8| ch == b'\n').expected("lf newline")
 }
@@ -120,7 +115,6 @@ where
 pub fn crlf<Input>() -> impl Parser<Input, Output = u8, PartialState = ()>
 where
     Input: Stream<Token = u8>,
-    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 {
     no_partial(satisfy(|ch: u8| ch == b'\r').with(newline())).expected("crlf newline")
 }
@@ -136,7 +130,6 @@ where
 pub fn tab<Input>() -> impl Parser<Input, Output = u8, PartialState = ()>
 where
     Input: Stream<Token = u8>,
-    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 {
     satisfy(|ch| ch == b'\t').expected("tab")
 }
@@ -152,7 +145,6 @@ where
 pub fn upper<Input>() -> impl Parser<Input, Output = u8, PartialState = ()>
 where
     Input: Stream<Token = u8>,
-    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 {
     byte_parser!(upper, Upper, is_ascii_uppercase)
 }
@@ -168,7 +160,6 @@ where
 pub fn lower<Input>() -> impl Parser<Input, Output = u8, PartialState = ()>
 where
     Input: Stream<Token = u8>,
-    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 {
     byte_parser!(lower, Lower, is_ascii_lowercase)
 }
@@ -185,7 +176,6 @@ where
 pub fn alpha_num<Input>() -> impl Parser<Input, Output = u8, PartialState = ()>
 where
     Input: Stream<Token = u8>,
-    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 {
     byte_parser!(alpha_num, AlphaNum, is_ascii_alphanumeric)
 }
@@ -202,7 +192,6 @@ where
 pub fn letter<Input>() -> impl Parser<Input, Output = u8, PartialState = ()>
 where
     Input: Stream<Token = u8>,
-    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 {
     byte_parser!(letter, Letter, is_ascii_alphabetic)
 }
@@ -218,7 +207,6 @@ where
 pub fn oct_digit<Input>() -> impl Parser<Input, Output = u8, PartialState = ()>
 where
     Input: Stream<Token = u8>,
-    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 {
     satisfy(|ch| (b'0'..=b'7').contains(&ch)).expected("octal digit")
 }
@@ -234,7 +222,6 @@ where
 pub fn hex_digit<Input>() -> impl Parser<Input, Output = u8, PartialState = ()>
 where
     Input: Stream<Token = u8>,
-    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 {
     byte_parser!(hex_digit, HexDigit, is_ascii_hexdigit())
 }
@@ -262,7 +249,6 @@ parser! {
 pub fn bytes['a, 'b, Input](s: &'static [u8])(Input) -> &'a [u8]
 where [
     Input: Stream<Token = u8, Range = &'b [u8]>,
-    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 ]
 {
     bytes_cmp(s, |l: u8, r: u8| l == r)
@@ -293,7 +279,6 @@ pub fn bytes_cmp['a, 'b, C, Input](s: &'static [u8], cmp: C)(Input) -> &'a [u8]
 where [
     C: FnMut(u8, u8) -> bool,
     Input: Stream<Token = u8, Range = &'b [u8]>,
-    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 ]
 {
     let s = *s;
@@ -457,7 +442,6 @@ pub mod num {
             pub fn $be_name<'a, Input>() -> impl Parser<Input, Output = $output_type, PartialState = ()>
             where
                 Input: Stream<Token = u8>,
-                Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
             {
                 parser(|input: &mut Input| {
                     let checkpoint = input.checkpoint();
@@ -479,7 +463,6 @@ pub mod num {
             pub fn $le_name<'a, Input>() -> impl Parser<Input, Output = $output_type, PartialState = ()>
             where
                 Input: Stream<Token = u8>,
-                Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
             {
                 parser(|input: &mut Input| {
                     let checkpoint = input.checkpoint();

--- a/src/parser/char.rs
+++ b/src/parser/char.rs
@@ -1,7 +1,6 @@
 //! Module containing parsers specialized on character streams.
 
 use crate::{
-    error::ParseError,
     parser::{
         combinator::no_partial,
         repeat::skip_many,
@@ -22,7 +21,6 @@ use crate::{
 pub fn char<Input>(c: char) -> Token<Input>
 where
     Input: Stream<Token = char>,
-    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 {
     token(c)
 }
@@ -63,7 +61,6 @@ parser! {
 pub fn space<Input>() -> impl Parser<Input, Output = char, PartialState = ()>
 where
     Input: Stream<Token = char>,
-    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 {
     let f: fn(char) -> bool = char::is_whitespace;
     satisfy(f).expected("whitespace")
@@ -84,7 +81,6 @@ where
 pub fn spaces<Input>() -> impl Parser<Input, Output = ()>
 where
     Input: Stream<Token = char>,
-    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 {
     skip_many(space()).expected("whitespaces")
 }
@@ -100,7 +96,6 @@ where
 pub fn newline<Input>() -> impl Parser<Input, Output = char, PartialState = ()>
 where
     Input: Stream<Token = char>,
-    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 {
     satisfy(|ch: char| ch == '\n').expected("lf newline")
 }
@@ -117,7 +112,6 @@ where
 pub fn crlf<Input>() -> impl Parser<Input, Output = char, PartialState = ()>
 where
     Input: Stream<Token = char>,
-    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 {
     no_partial(satisfy(|ch: char| ch == '\r').with(newline())).expected("crlf newline")
 }
@@ -133,7 +127,6 @@ where
 pub fn tab<Input>() -> impl Parser<Input, Output = char, PartialState = ()>
 where
     Input: Stream<Token = char>,
-    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 {
     satisfy(|ch: char| ch == '\t').expected("tab")
 }
@@ -151,7 +144,6 @@ where
 pub fn upper<Input>() -> impl Parser<Input, Output = char, PartialState = ()>
 where
     Input: Stream<Token = char>,
-    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 {
     satisfy(|ch: char| ch.is_uppercase()).expected("uppercase letter")
 }
@@ -169,7 +161,6 @@ where
 pub fn lower<Input>() -> impl Parser<Input, Output = char, PartialState = ()>
 where
     Input: Stream<Token = char>,
-    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 {
     satisfy(|ch: char| ch.is_lowercase()).expected("lowercase letter")
 }
@@ -188,7 +179,6 @@ where
 pub fn alpha_num<Input>() -> impl Parser<Input, Output = char, PartialState = ()>
 where
     Input: Stream<Token = char>,
-    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 {
     satisfy(|ch: char| ch.is_alphanumeric()).expected("letter or digit")
 }
@@ -207,7 +197,6 @@ where
 pub fn letter<Input>() -> impl Parser<Input, Output = char, PartialState = ()>
 where
     Input: Stream<Token = char>,
-    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 {
     satisfy(|ch: char| ch.is_alphabetic()).expected("letter")
 }
@@ -223,7 +212,6 @@ where
 pub fn oct_digit<Input>() -> impl Parser<Input, Output = char, PartialState = ()>
 where
     Input: Stream<Token = char>,
-    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 {
     satisfy(|ch: char| ch.is_digit(8)).expected("octal digit")
 }
@@ -239,7 +227,6 @@ where
 pub fn hex_digit<Input>() -> impl Parser<Input, Output = char, PartialState = ()>
 where
     Input: Stream<Token = char>,
-    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 {
     satisfy(|ch: char| ch.is_digit(0x10)).expected("hexadecimal digit")
 }
@@ -260,7 +247,6 @@ where
 pub fn string<'a, Input>(s: &'static str) -> impl Parser<Input, Output = &'a str>
 where
     Input: Stream<Token = char>,
-    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 {
     string_cmp(s, |l, r| l == r)
 }
@@ -282,7 +268,6 @@ pub fn string_cmp<'a, C, Input>(s: &'static str, cmp: C) -> impl Parser<Input, O
 where
     C: FnMut(char, char) -> bool,
     Input: Stream<Token = char>,
-    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 {
     tokens_cmp(s.chars(), cmp).map(move |_| s).expected(s)
 }

--- a/src/parser/combinator.rs
+++ b/src/parser/combinator.rs
@@ -360,7 +360,6 @@ where
     P: Parser<Input>,
     F: FnMut(P::Output) -> Result<O, E>,
     E: Into<<Input::Error as ParseError<Input::Token, Input::Range, Input::Position>>::StreamError>,
-    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 {
     type Output = O;
     type PartialState = P::PartialState;
@@ -1002,7 +1001,6 @@ where
 /// fn example<Input>() -> impl Parser<Input, Output = (char, char), PartialState = AnySendSyncPartialState>
 /// where
 ///     Input: Stream<Token = char>,
-///     Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 /// {
 ///     any_send_sync_partial_state((letter(), letter()))
 /// }
@@ -1374,7 +1372,6 @@ pub type FnOpaque<Input, O, S = ()> =
 /// fn expr<Input>() -> FnOpaque<Input, Expr>
 /// where
 ///     Input: Stream<Token = char>,
-///     Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 /// {
 ///     opaque!(
 ///         // `no_partial` disables partial parsing and replaces the partial state with `()`,
@@ -1517,7 +1514,6 @@ impl<Input, P, Q> Parser<Input> for Spanned<P>
 where
     P: Parser<Input>,
     Input: Stream<Position = Span<Q>>,
-    Input::Error: ParseError<Input::Token, Input::Range, Span<Q>>,
     Q: Ord + Clone,
 {
     type Output = P::Output;

--- a/src/parser/function.rs
+++ b/src/parser/function.rs
@@ -144,7 +144,6 @@ where
 /// impl Interner {
 ///     fn string<Input>(&self, input: &mut Input) -> StdParseResult<u32, Input>
 ///         where Input: Stream<Token = char>,
-///               Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 ///     {
 ///         many(letter())
 ///             .map(|s: String| self.0.get(&s).cloned().unwrap_or(0))

--- a/src/parser/sequence.rs
+++ b/src/parser/sequence.rs
@@ -109,7 +109,6 @@ macro_rules! tuple_parser {
                 $h: &mut $h $(, $id : &mut $id )*
             ) -> ParseResult<($h::Output, $($id::Output),*), <Input as StreamOnce>::Error>
                 where Input: Stream,
-                      Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
                       $h: Parser<Input>,
                       $($id: Parser<Input>),*
             {
@@ -143,7 +142,6 @@ macro_rules! tuple_parser {
         #[allow(non_snake_case)]
         impl <Input: Stream, $h:, $($id:),*> Parser<Input> for ($h, $($id),*)
             where Input: Stream,
-                  Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
                   $h: Parser<Input>,
                   $($id: Parser<Input>),*
         {

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -165,7 +165,6 @@ pub trait Stream: StreamOnce + ResetStream + Positioned {}
 impl<Input> Stream for Input
 where
     Input: StreamOnce + Positioned + ResetStream,
-    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 {
 }
 

--- a/src/stream/position.rs
+++ b/src/stream/position.rs
@@ -111,13 +111,13 @@ where
     }
 }
 
-impl<Input, X, E> Positioned for Stream<Input, X>
+impl<Input, X, S> Positioned for Stream<Input, X>
 where
     Input: StreamOnce,
     X: Positioner<Input::Token>,
-    E: StreamError<Input::Token, Input::Range>,
-    Input::Error: ParseError<Input::Token, Input::Range, X::Position, StreamError = E>,
-    Input::Error: ParseError<Input::Token, Input::Range, Input::Position, StreamError = E>,
+    S: StreamError<Input::Token, Input::Range>,
+    Input::Error: ParseError<Input::Token, Input::Range, X::Position, StreamError = S>,
+    Input::Error: ParseError<Input::Token, Input::Range, Input::Position, StreamError = S>,
 {
     #[inline]
     fn position(&self) -> Self::Position {
@@ -130,8 +130,8 @@ where
     Input: StreamOnce,
     X: Positioner<Input::Token>,
     S: StreamError<Input::Token, Input::Range>,
-    Input::Error: ParseError<Input::Token, Input::Range, X::Position, StreamError = S>
-        + ParseError<Input::Token, Input::Range, Input::Position, StreamError = S>,
+    Input::Error: ParseError<Input::Token, Input::Range, X::Position, StreamError = S>,
+    Input::Error: ParseError<Input::Token, Input::Range, Input::Position, StreamError = S>,
 {
     type Token = Input::Token;
     type Range = Input::Range;

--- a/tests/async.rs
+++ b/tests/async.rs
@@ -277,8 +277,6 @@ fn content_length<'a, Input>(
 ) -> impl Parser<Input, Output = String, PartialState = AnySendPartialState> + 'a
 where
     Input: RangeStream<Token = char, Range = &'a str> + 'a,
-    // Necessary due to rust-lang/rust#24159
-    Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 {
     let content_length = range("Content-Length: ").with(
         range::recognize(skip_many1(digit())).and_then(|digits: &str| {


### PR DESCRIPTION
Due to an old Rust bug, rust-lang/rust#24159, many parsers included an extraneous trait bound for Input::Error as a workaround. That bug has been closed since February 2021, and the workaround is no longer needed.

There are a few places I did NOT remove `Input::Error` bound from the `where` clause, which would be nice to eliminate but I think may be required:
- stream/position.rs requires it to specify the `StreamError` associated type in the `Positioned` and `StreamOnce` implementations.
- stream/easy.rs similarly requires it to specify `StreamError` in the docs example
- parser/combinator.rs requires `Into<...::StreamError>` for the error generic in its `AndThen` struct
- src/lib.rs has similar awkward boilerplate for `...:StreamError: From<ParseIntError>` in its docs examples