### PR TITLE
perf: avoid initializing huge buffers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,11 @@ name = "mp4"
 harness = false
 required-features = ["mp4"]
 
+[[bench]]
+name = "buffers"
+harness = false
+required-features = ["std"]
+
 [[example]]
 name = "async"
 required-features = ["std", "tokio"]

--- a/benches/buffers.rs
+++ b/benches/buffers.rs
@@ -1,0 +1,86 @@
+#![cfg(feature = "std")]
+
+use {
+    combine::{
+        parser::{
+            byte::take_until_bytes,
+            combinator::{any_send_sync_partial_state, recognize, AnySendSyncPartialState},
+        },
+        Parser, RangeStream,
+    },
+    criterion::{black_box, criterion_group, criterion_main, Bencher, Criterion},
+    partial_io::{PartialOp, PartialRead},
+    std::io::Cursor,
+};
+
+fn test_data() -> Vec<u8> {
+    let mut input = vec![b' '; 5_000_000];
+    input.push(b'1');
+
+    input
+}
+
+fn parser<'a, I>() -> impl combine::Parser<I, Output = usize, PartialState = AnySendSyncPartialState>
+where
+    I: RangeStream<Token = u8, Range = &'a [u8]>,
+    I::Error: combine::ParseError<u8, &'a [u8], I::Position>,
+{
+    any_send_sync_partial_state(
+        recognize(take_until_bytes(&b"1"[..])).map(|spaces: Vec<u8>| spaces.len()),
+    )
+}
+
+fn bench_small_buf(bencher: &mut Bencher<'_>) {
+    let input = test_data();
+    let mut decoder = combine::stream::decoder::Decoder::new();
+
+    bencher.iter(|| {
+        let cursor = Cursor::new(&input);
+        let mut partial_read =
+            PartialRead::new(cursor, std::iter::repeat(PartialOp::Limited(1000)));
+        let mut ref_decoder = &mut decoder;
+
+        let result = combine::decode!(ref_decoder, partial_read, parser(), |input, _position| {
+            combine::easy::Stream::from(input)
+        },);
+
+        match result {
+            Ok(usize) => black_box(usize),
+            Err(err) => {
+                println!("{:?}", err);
+                panic!();
+            }
+        };
+    });
+}
+
+fn bench_big_buf(bencher: &mut Bencher<'_>) {
+    let input = test_data();
+    let mut decoder = combine::stream::decoder::Decoder::new();
+
+    bencher.iter(|| {
+        let cursor = Cursor::new(&input);
+        let mut partial_read = PartialRead::new(cursor, std::iter::repeat(PartialOp::Unlimited));
+        let mut ref_decoder = &mut decoder;
+
+        let result = combine::decode!(ref_decoder, partial_read, parser(), |input, _position| {
+            combine::easy::Stream::from(input)
+        },);
+
+        match result {
+            Ok(usize) => black_box(usize),
+            Err(err) => {
+                println!("{:?}", err);
+                panic!();
+            }
+        };
+    });
+}
+
+fn bench(c: &mut Criterion) {
+    c.bench_function("buffers_small", bench_small_buf);
+    c.bench_function("buffers_big", bench_big_buf);
+}
+
+criterion_group!(buffers, bench);
+criterion_main!(buffers);

--- a/src/stream/buf_reader.rs
+++ b/src/stream/buf_reader.rs
@@ -8,11 +8,7 @@ use std::io::{self, BufRead, Read};
 ))]
 use std::pin::Pin;
 
-#[cfg(any(
-    feature = "futures-03",
-    feature = "tokio-02",
-    feature = "tokio-03"
-))]
+#[cfg(any(feature = "futures-03", feature = "tokio-02", feature = "tokio-03"))]
 use std::mem::MaybeUninit;
 
 #[cfg(feature = "futures-core-03")]
@@ -361,14 +357,17 @@ fn extend_buf_sync<R>(buf: &mut BytesMut, read: &mut R) -> io::Result<usize>
 where
     R: Read,
 {
+    let size = 8 * 1024;
     if !buf.has_remaining_mut() {
-        buf.reserve(8 * 1024);
+        buf.reserve(size);
     }
 
     // Copy of tokio's poll_read_buf method (but it has to force initialize the buffer)
     let n = {
         let bs = buf.chunk_mut();
 
+        let initial_size = bs.len().min(size);
+        let bs = &mut bs[..initial_size];
         for i in 0..bs.len() {
             bs.write_byte(i, 0);
         }


### PR DESCRIPTION
Addressing the issue: https://github.com/Marwes/combine/issues/364 

Avoid initializing continuously increasing buffers and limit the size to: `8 * 1024`

* Adding fix
* Also adding benchmarks for buffers

But one thing I noticed if we use bigger data like 200 MB. The new code behaves significantly slower like 10x. Maybe we should add this code behind feature flag?

Before: 
```
Gnuplot not found, using plotters backend
buffers_small         time:   [1.6066 µs 1.7055 µs 1.8335 µs]
Found 12 outliers among 100 measurements (12.00%)
  4 (4.00%) high mild
  8 (8.00%) high severe

buffers_big           time:   [39.428 ns 39.802 ns 40.332 ns]
Found 11 outliers among 100 measurements (11.00%)
  5 (5.00%) high mild
  6 (6.00%) high severe
```


After:
```
buffers_small         time:   [160.24 ns 170.23 ns 182.88 ns]
                        change: [-95.166% -91.191% -84.012%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  4 (4.00%) high mild
  8 (8.00%) high severe

buffers_big           time:   [41.895 ns 42.547 ns 43.386 ns]
                        change: [+1.6991% +26.314% +58.727%] (p = 0.06 > 0.05)
                        No change in performance detected.
Found 12 outliers among 100 measurements (12.00%)
  4 (4.00%) high mild
  8 (8.00%) high severe
```


Also did some tests in redis-rs lib:
Before:
```
Connected to redis. Starting the loop
LoopNumber: 1, RedisGet latency_ms=79, value.is_some()=true
LoopNumber: 2, RedisGet latency_ms=135, value.is_some()=true
LoopNumber: 3, RedisGet latency_ms=130, value.is_some()=true
LoopNumber: 4, RedisGet latency_ms=129, value.is_some()=true
LoopNumber: 5, RedisGet latency_ms=128, value.is_some()=true
LoopNumber: 6, RedisGet latency_ms=133, value.is_some()=true
LoopNumber: 7, RedisGet latency_ms=128, value.is_some()=true
LoopNumber: 8, RedisGet latency_ms=129, value.is_some()=true
LoopNumber: 9, RedisGet latency_ms=129, value.is_some()=true
```

After:
```
Connecting to redis
Connected to redis. Starting the loop
LoopNumber: 1, RedisGet latency_ms=19, value.is_some()=true
LoopNumber: 2, RedisGet latency_ms=14, value.is_some()=true
LoopNumber: 3, RedisGet latency_ms=16, value.is_some()=true
LoopNumber: 4, RedisGet latency_ms=16, value.is_some()=true
LoopNumber: 5, RedisGet latency_ms=17, value.is_some()=true
LoopNumber: 6, RedisGet latency_ms=16, value.is_some()=true
LoopNumber: 7, RedisGet latency_ms=15, value.is_some()=true
LoopNumber: 8, RedisGet latency_ms=15, value.is_some()=true
LoopNumber: 9, RedisGet latency_ms=16, value.is_some()=true
```

