### PR TITLE
warn on `missing-debug-implementations`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,9 @@ edition = "2018"
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
+[lints.rust]
+missing-debug-implementations = "warn"
+
 [lib]
 name = "combine"
 path = "src/lib.rs"

--- a/src/error.rs
+++ b/src/error.rs
@@ -123,6 +123,7 @@ impl<R> ErrorInfo<'_, Self, R> for u8 {
 }
 
 /// Newtype which constructs an `Info::Token` through `ErrorInfo`
+#[derive(Debug)]
 pub struct Token<T>(pub T);
 
 impl<T, R> From<Token<T>> for Info<T, R, &'static str> {
@@ -142,6 +143,7 @@ where
 }
 
 /// Newtype which constructs an `Info::Range` through `ErrorInfo`
+#[derive(Debug)]
 pub struct Range<R>(pub R);
 
 impl<T, R> From<Range<R>> for Info<T, R, &'static str> {
@@ -162,6 +164,7 @@ where
 
 /// Newtype which constructs an `Info::Static` through `ErrorInfo`
 /// A plain `&'static str` can also be used, this exists for consistency.
+#[derive(Debug)]
 pub struct Static(&'static str);
 
 impl<T, R, F> From<Static> for Info<T, R, F>
@@ -181,6 +184,7 @@ impl<'s, T, R> ErrorInfo<'s, T, R> for Static {
 }
 
 /// Newtype which constructs an `Info::Format` through `ErrorInfo`
+#[derive(Debug)]
 pub struct Format<F>(pub F)
 where
     F: fmt::Display;

--- a/src/future_ext.rs
+++ b/src/future_ext.rs
@@ -4,6 +4,7 @@ use crate::lib::pin::Pin;
 use crate::lib::task::{Context, Poll};
 
 // Replace usage of this with std::future::poll_fn once it stabilizes
+#[derive(Debug)]
 pub struct PollFn<F> {
     f: F,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,7 +188,7 @@
     clippy::inline_always,
     clippy::type_complexity,
     clippy::too_many_arguments,
-    clippy::match_like_matches_macro
+    clippy::match_like_matches_macro,
 )]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
@@ -427,6 +427,7 @@ macro_rules! combine_parser_impl {
     ) => {
 
         $(#[$derive])*
+        #[allow(missing_debug_implementations)]
         $struct_vis struct $type_name<$($type_params)*>
             where <$input_type as $crate::stream::StreamOnce>::Error:
                 $crate::error::ParseError<

--- a/src/parser/choice.rs
+++ b/src/parser/choice.rs
@@ -217,6 +217,7 @@ macro_rules! tuple_choice_parser {
 macro_rules! tuple_choice_parser_inner {
     ($partial_state: ident; $($id: ident)+) => {
         #[doc(hidden)]
+        #[allow(missing_debug_implementations)]
         pub enum $partial_state<$($id),+> {
             Peek,
             $(
@@ -350,7 +351,7 @@ array_choice_parser!(
     30 31 32
 );
 
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct Choice<P>(P);
 
 impl<Input, P> Parser<Input> for Choice<P>
@@ -557,7 +558,7 @@ where
     Choice(ps)
 }
 
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct Or<P1, P2>(Choice<(P1, P2)>);
 impl<Input, O, P1, P2> Parser<Input> for Or<P1, P2>
 where
@@ -630,7 +631,7 @@ where
     Or(choice((p1, p2)))
 }
 
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct Optional<P>(P);
 impl<Input, P> Parser<Input> for Optional<P>
 where

--- a/src/parser/combinator.rs
+++ b/src/parser/combinator.rs
@@ -18,7 +18,7 @@ use alloc::{boxed::Box, string::String, vec::Vec};
 #[cfg(feature = "alloc")]
 use crate::lib::any::Any;
 
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct NotFollowedBy<P>(P);
 impl<Input, O, P> Parser<Input> for NotFollowedBy<P>
 where
@@ -86,7 +86,7 @@ where
  * TODO :: Rename `Try` to `Attempt`
  * Because this is public, it's name cannot be changed without also making a breaking change.
  */
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct Try<P>(P);
 impl<Input, O, P> Parser<Input> for Try<P>
 where
@@ -164,7 +164,7 @@ where
     Try(p)
 }
 
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct LookAhead<P>(P);
 
 impl<Input, O, P> Parser<Input> for LookAhead<P>
@@ -211,7 +211,7 @@ where
     LookAhead(p)
 }
 
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct Map<P, F>(P, F);
 impl<Input, A, B, P, F> Parser<Input> for Map<P, F>
 where
@@ -256,7 +256,7 @@ where
     Map(p, f)
 }
 
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct MapInput<P, F>(P, F);
 impl<Input, A, B, P, F> Parser<Input> for MapInput<P, F>
 where
@@ -301,7 +301,7 @@ where
     MapInput(p, f)
 }
 
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct FlatMap<P, F>(P, F);
 impl<Input, A, B, P, F> Parser<Input> for FlatMap<P, F>
 where
@@ -352,7 +352,7 @@ where
     FlatMap(p, f)
 }
 
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct AndThen<P, F>(P, F);
 impl<Input, P, F, O, E> Parser<Input> for AndThen<P, F>
 where
@@ -423,7 +423,7 @@ where
     AndThen(p, f)
 }
 
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct Recognize<F, P>(P, PhantomData<fn() -> F>);
 
 impl<F, P> Recognize<F, P> {
@@ -548,6 +548,7 @@ where
     Recognize(parser, PhantomData)
 }
 
+#[derive(Debug)]
 pub enum Either<L, R> {
     Left(L),
     Right(R),
@@ -629,6 +630,7 @@ where
     }
 }
 
+#[derive(Debug)]
 pub struct NoPartial<P>(P);
 
 impl<Input, P> Parser<Input> for NoPartial<P>
@@ -672,7 +674,7 @@ where
     NoPartial(p)
 }
 
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct Ignore<P>(P);
 impl<Input, P> Parser<Input> for Ignore<P>
 where
@@ -718,11 +720,12 @@ where
 
 #[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct AnyPartialState(Option<Box<dyn Any>>);
 
 #[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+#[derive(Debug)]
 pub struct AnyPartialStateParser<P>(P);
 
 #[cfg(feature = "alloc")]
@@ -821,11 +824,12 @@ where
 
 #[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct AnySendPartialState(Option<Box<dyn Any + Send>>);
 
 #[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+#[derive(Debug)]
 pub struct AnySendPartialStateParser<P>(P);
 
 #[cfg(feature = "alloc")]
@@ -924,11 +928,12 @@ where
 
 #[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct AnySendSyncPartialState(Option<Box<dyn Any + Send + Sync>>);
 
 #[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+#[derive(Debug)]
 pub struct AnySendSyncPartialStateParser<P>(P);
 
 #[cfg(feature = "alloc")]
@@ -1023,7 +1028,7 @@ where
     AnySendSyncPartialStateParser(p)
 }
 
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct Lazy<P>(P);
 impl<Input, O, P, R> Parser<Input> for Lazy<P>
 where
@@ -1094,7 +1099,7 @@ where
     Lazy(p)
 }
 
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct Factory<P, R>(P, Option<R>);
 
 impl<P, R> Factory<P, R> {
@@ -1285,7 +1290,7 @@ where [
 }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct Opaque<F, Input, O, S>(F, PhantomData<fn(&mut Input, &mut S) -> O>);
 impl<Input, F, O, S> Parser<Input> for Opaque<F, Input, O, S>
 where
@@ -1421,6 +1426,7 @@ macro_rules! opaque {
     };
 }
 
+#[derive(Debug)]
 pub struct InputConverter<InputInner, P, C>
 where
     InputInner: Stream,
@@ -1508,7 +1514,7 @@ where
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct Spanned<P>(P);
 impl<Input, P, Q> Parser<Input> for Spanned<P>
 where

--- a/src/parser/error.rs
+++ b/src/parser/error.rs
@@ -11,7 +11,7 @@ use crate::{
     Parser, Stream, StreamOnce,
 };
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct Unexpected<I, T, E>(E, PhantomData<fn(I) -> (I, T)>)
 where
     I: Stream;
@@ -92,7 +92,7 @@ where
     Unexpected(message, PhantomData)
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct Message<P, S>(P, S);
 impl<Input, P, S> Parser<Input> for Message<P, S>
 where
@@ -149,7 +149,7 @@ where
     Message(p, msg)
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct Expected<P, S>(P, S);
 impl<Input, P, S> Parser<Input> for Expected<P, S>
 where
@@ -195,7 +195,7 @@ where
     Expected(p, info)
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct Silent<P>(P);
 impl<Input, P> Parser<Input> for Silent<P>
 where

--- a/src/parser/function.rs
+++ b/src/parser/function.rs
@@ -19,7 +19,7 @@ impl<'a, Input: Stream, O> Parser<Input>
     }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct FnParser<Input, F>(F, PhantomData<fn(Input) -> Input>);
 
 /// Wraps a function, turning it into a parser.
@@ -93,7 +93,7 @@ where
     }
 }
 
-#[derive(Copy)]
+#[derive(Debug, Copy)]
 pub struct EnvParser<E, Input, T>
 where
     Input: Stream,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1147,7 +1147,7 @@ pub trait ParseMode: Copy {
 
 /// Internal API. May break without a semver bump
 #[doc(hidden)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct FirstMode;
 impl ParseMode for FirstMode {
     #[inline]
@@ -1173,7 +1173,7 @@ impl ParseMode for FirstMode {
 
 /// Internal API. May break without a semver bump
 #[doc(hidden)]
-#[derive(Copy, Clone, Default)]
+#[derive(Debug, Copy, Clone, Default)]
 pub struct PartialMode {
     pub first: bool,
 }

--- a/src/parser/range.rs
+++ b/src/parser/range.rs
@@ -28,6 +28,7 @@ use crate::stream::{
 
 use crate::Parser;
 
+#[derive(Debug)]
 pub struct Range<Input>(Input::Range)
 where
     Input: RangeStream;
@@ -146,7 +147,7 @@ where
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct RecognizeWithValue<P>(P);
 
 impl<Input, P> Parser<Input> for RecognizeWithValue<P>
@@ -256,6 +257,7 @@ where
     Range(i)
 }
 
+#[derive(Debug)]
 pub struct Take<Input>(usize, PhantomData<fn(Input)>);
 impl<Input> Parser<Input> for Take<Input>
 where
@@ -300,6 +302,7 @@ where
     Take(n, PhantomData)
 }
 
+#[derive(Debug)]
 pub struct TakeWhile<Input, F>(F, PhantomData<fn(Input) -> Input>);
 impl<Input, F> Parser<Input> for TakeWhile<Input, F>
 where
@@ -358,6 +361,7 @@ where
     TakeWhile(f, PhantomData)
 }
 
+#[derive(Debug)]
 pub struct TakeWhile1<Input, F>(F, PhantomData<fn(Input) -> Input>);
 impl<Input, F> Parser<Input> for TakeWhile1<Input, F>
 where
@@ -416,6 +420,7 @@ where
     TakeWhile1(f, PhantomData)
 }
 
+#[derive(Debug)]
 pub struct TakeUntilRange<Input>(Input::Range)
 where
     Input: RangeStream;
@@ -548,6 +553,7 @@ impl From<Option<usize>> for TakeRange {
     }
 }
 
+#[derive(Debug)]
 pub struct TakeFn<F, Input> {
     searcher: F,
     _marker: PhantomData<fn(Input)>,

--- a/src/parser/regex.rs
+++ b/src/parser/regex.rs
@@ -218,6 +218,7 @@ mod regex {
     }
 }
 
+#[derive(Debug)]
 pub struct Match<R, Input>(R, PhantomData<Input>);
 
 impl<'a, Input, R> Parser<Input> for Match<R, Input>
@@ -273,7 +274,7 @@ where
     Match(regex, PhantomData)
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct Find<R, Input>(R, PhantomData<fn() -> Input>);
 
 impl<'a, Input, R> Parser<Input> for Find<R, Input>
@@ -334,7 +335,7 @@ where
     Find(regex, PhantomData)
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct FindMany<F, R, Input>(R, PhantomData<fn() -> (Input, F)>);
 
 impl<'a, Input, F, R> Parser<Input> for FindMany<F, R, Input>
@@ -392,7 +393,7 @@ where
     FindMany(regex, PhantomData)
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct Captures<F, R, Input>(R, PhantomData<fn() -> (Input, F)>);
 
 impl<'a, Input, F, R> Parser<Input> for Captures<F, R, Input>
@@ -460,7 +461,7 @@ where
     Captures(regex, PhantomData)
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct CapturesMany<F, G, R, Input>(R, PhantomData<fn() -> (Input, F, G)>);
 
 impl<'a, Input, F, G, R> Parser<Input> for CapturesMany<F, G, R, Input>

--- a/src/parser/repeat.rs
+++ b/src/parser/repeat.rs
@@ -72,7 +72,7 @@ parser! {
     }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct CountMinMax<F, P> {
     parser: P,
     min: usize,
@@ -243,6 +243,29 @@ where
     mode: M,
 }
 
+use std::fmt;
+
+impl<'a, Input, P, S, M> fmt::Debug for Iter<'a, Input, P, S, M>
+where
+    Input: Stream,
+    P: Parser<Input> + fmt::Debug,
+    S: fmt::Debug,
+    M: fmt::Debug,
+    <Input as StreamOnce>::Error: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Iter")
+            .field("parser", &self.parser)
+            .field("input", &format_args!("<Input>"))
+            .field("committed", &self.committed)
+            .field("state", &self.state)
+            .field("partial_state", &self.partial_state)
+            .field("mode", &self.mode)
+            .finish()
+    }
+}
+
+#[derive(Debug)]
 enum State<E> {
     Ok,
     PeekErr(E),
@@ -374,7 +397,7 @@ where
     }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct Many<F, P>(P, PhantomData<F>);
 
 impl<F, Input, P> Parser<Input> for Many<F, P>
@@ -447,7 +470,7 @@ where
     Many(p, PhantomData)
 }
 
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct Many1<F, P>(P, PhantomData<fn() -> F>);
 impl<F, Input, P> Parser<Input> for Many1<F, P>
 where
@@ -535,7 +558,7 @@ where
     Many1(p, PhantomData)
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 #[doc(hidden)]
 // FIXME Should not be public
 pub struct Sink;
@@ -609,7 +632,7 @@ where [
 }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct SepBy<F, P, S> {
     parser: P,
     separator: S,
@@ -684,7 +707,7 @@ where
     }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct SepBy1<F, P, S> {
     parser: P,
     separator: S,
@@ -791,7 +814,7 @@ where
     }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct SepEndBy<F, P, S> {
     parser: P,
     separator: S,
@@ -865,7 +888,7 @@ where
     }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct SepEndBy1<F, P, S> {
     parser: P,
     separator: S,
@@ -977,7 +1000,7 @@ where
     }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct Chainl1<P, Op>(P, Op);
 impl<Input, P, Op> Parser<Input> for Chainl1<P, Op>
 where
@@ -1067,7 +1090,7 @@ where
     Chainl1(parser, op)
 }
 
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct Chainr1<P, Op>(P, Op);
 impl<Input, P, Op> Parser<Input> for Chainr1<P, Op>
 where
@@ -1139,7 +1162,7 @@ where
     Chainr1(parser, op)
 }
 
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct TakeUntil<F, P> {
     end: P,
     _marker: PhantomData<fn() -> F>,
@@ -1261,7 +1284,7 @@ parser! {
     }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct RepeatUntil<F, P, E> {
     parser: P,
     end: E,
@@ -1373,9 +1396,10 @@ parser! {
     }
 }
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct EscapedState<T, U>(PhantomData<(T, U)>);
 
+#[derive(Debug)]
 pub struct Escaped<P, Q, I> {
     parser: P,
     escape: I,
@@ -1487,6 +1511,7 @@ where
     }
 }
 
+#[derive(Debug)]
 pub struct Iterate<F, I, P> {
     parser: P,
     iterable: I,

--- a/src/parser/sequence.rs
+++ b/src/parser/sequence.rs
@@ -21,6 +21,7 @@ macro_rules! count {
 }
 
 #[doc(hidden)]
+#[derive(Debug)]
 pub struct SequenceState<T, U> {
     pub value: Option<T>,
     pub state: U,
@@ -86,7 +87,7 @@ where
 macro_rules! tuple_parser {
     ($partial_state: ident; $h: ident $(, $id: ident)*) => {
         #[allow(non_snake_case)]
-        #[derive(Default)]
+        #[derive(Debug, Default)]
         pub struct $partial_state < $h $(, $id )* > {
             pub $h: $h,
             $(
@@ -505,7 +506,7 @@ macro_rules! struct_parser {
     }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct With<P1, P2>((Ignore<P1>, P2));
 impl<Input, P1, P2> Parser<Input> for With<P1, P2>
 where
@@ -553,7 +554,7 @@ where
     With((ignore(p1), p2))
 }
 
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct Skip<P1, P2>((P1, Ignore<P2>));
 impl<Input, P1, P2> Parser<Input> for Skip<P1, P2>
 where
@@ -591,7 +592,7 @@ where
 }
 
 parser! {
-    #[derive(Copy, Clone)]
+    #[derive(Debug, Copy, Clone)]
     pub struct Between;
     type PartialState = <Map<(L, P, R), fn ((L::Output, P::Output, R::Output)) -> P::Output> as Parser<Input>>::PartialState;
 /// Parses `open` followed by `parser` followed by `close`.
@@ -623,7 +624,7 @@ where [
 }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct Then<P, F>(P, F);
 impl<Input, P, N, F> Parser<Input> for Then<P, F>
 where
@@ -713,7 +714,7 @@ where
     Then(p, f)
 }
 
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct ThenPartial<P, F>(P, F);
 impl<Input, P, N, F> Parser<Input> for ThenPartial<P, F>
 where
@@ -810,7 +811,7 @@ mod tests {
     }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct ThenRef<P, F>(P, F);
 impl<Input, P, N, F> Parser<Input> for ThenRef<P, F>
 where

--- a/src/parser/token.rs
+++ b/src/parser/token.rs
@@ -11,7 +11,7 @@ use crate::{
     Parser,
 };
 
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct Any<Input>(PhantomData<fn(Input) -> Input>);
 
 impl<Input> Parser<Input> for Any<Input>
@@ -48,7 +48,7 @@ where
     Any(PhantomData)
 }
 
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct Satisfy<Input, P> {
     predicate: P,
     _marker: PhantomData<Input>,
@@ -112,7 +112,7 @@ where
     }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct SatisfyMap<Input, P> {
     predicate: P,
     _marker: PhantomData<Input>,
@@ -166,7 +166,7 @@ where
     }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct Token<Input>
 where
     Input: Stream,
@@ -216,7 +216,7 @@ where
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct Tokens<C, E, T, Input>
 where
     Input: Stream,
@@ -321,7 +321,7 @@ where
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct TokensCmp<C, T, Input>
 where
     Input: Stream,
@@ -420,7 +420,7 @@ where
     }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct Position<Input>
 where
     Input: Stream,
@@ -465,7 +465,7 @@ where
     }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct OneOf<T, Input>
 where
     Input: Stream,
@@ -518,7 +518,7 @@ where
     }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct NoneOf<T, Input>
 where
     Input: Stream,
@@ -576,7 +576,7 @@ where
     }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct Value<Input, T>(T, PhantomData<fn(Input) -> Input>);
 impl<Input, T> Parser<Input> for Value<Input, T>
 where
@@ -611,7 +611,7 @@ where
     Value(v, PhantomData)
 }
 
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct Produce<Input, F>(F, PhantomData<fn(Input) -> Input>);
 impl<Input, F, R> Parser<Input> for Produce<Input, F>
 where
@@ -647,7 +647,7 @@ where
     Produce(f, PhantomData)
 }
 
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct Eof<Input>(PhantomData<Input>);
 impl<Input> Parser<Input> for Eof<Input>
 where

--- a/src/stream/buf_reader.rs
+++ b/src/stream/buf_reader.rs
@@ -179,7 +179,7 @@ where
 }
 
 /// Marker used by `Decoder` for an internal buffer
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct Buffer(pub(crate) BytesMut);
 
 impl sealed::Sealed for Buffer {}
@@ -324,7 +324,7 @@ fn tokio_read_buf(
 }
 
 /// Marker used by `Decoder` for an external buffer
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct Bufferless;
 
 impl sealed::Sealed for Bufferless {}

--- a/src/stream/decoder.rs
+++ b/src/stream/decoder.rs
@@ -48,7 +48,7 @@ impl<E: fmt::Display, P: fmt::Display> fmt::Display for Error<E, P> {
     }
 }
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 /// Used together with the `decode!` macro
 pub struct Decoder<S, P, C = Buffer> {
     position: P,

--- a/src/stream/read.rs
+++ b/src/stream/read.rs
@@ -154,6 +154,7 @@ where
     }
 }
 
+#[derive(Debug)]
 pub struct Stream<R> {
     bytes: Bytes<R>,
 }


### PR DESCRIPTION
All public types should implement `Debug`. See <https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#missing-debug-implementations>.

I was writing a library that depends on this and came across the case where I couldn't derive `Debug` because the underlying types don't implement `Debug`.