### PR TITLE
Exclude development scripts from published package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ categories = ["parsing", "no-std"]
 license = "MIT"
 
 edition = "2018"
+include = ["Cargo.toml", "README.md", "CHANGELOG.md", "LICENSE", "src/**/*.rs"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/ci.sh
+++ b/ci.sh
@@ -16,3 +16,4 @@ cargo "$@" test --no-default-features --examples
 
 cargo "$@" check --no-default-features --features tokio-02
 cargo "$@" check --no-default-features --features tokio-03
+cargo "$@" package --all-features

--- a/src/error.rs
+++ b/src/error.rs
@@ -73,7 +73,7 @@ where
     F: fmt::Display + 's,
 {
     type Format = &'s F;
-    fn into_info(&'s self) -> Info<T, R, <Self as ErrorInfo<'_, T, R>>::Format> {
+    fn into_info(&'s self) -> Info<T, R, <Self as ErrorInfo<'s, T, R>>::Format> {
         match self {
             Info::Token(b) => Info::Token(b.clone()),
             Info::Range(b) => Info::Range(b.clone()),

--- a/src/parser/choice.rs
+++ b/src/parser/choice.rs
@@ -495,6 +495,7 @@ where
         slice_parse_mode(self, crate::parser::FirstMode, input, state)
     }
 
+    #[allow(dead_code)] // this needs to be there for rust 1.61
     #[inline]
     fn parse_mode_choice<M>(
         &mut self,


### PR DESCRIPTION
During a dependency review we noticed that the combine crate includes various development scripts. These development scripts shouldn't be there as they might, at some point become problematic. As of now they prevent any downstream user from enabling the `[bans.build.interpreted]` option of cargo deny.

I opted for using an explicit include list instead of an exclude list to prevent these files from being included in the published packages to make sure that everything that's included is an conscious choice.

This PR also fixes two warnings that occur while compiling the package