### PR TITLE
parser/combinator: Drop superfluous semicolon in `opaque`

### DIFF
--- a/src/parser/combinator.rs
+++ b/src/parser/combinator.rs
@@ -1434,7 +1434,7 @@ where
 #[macro_export]
 macro_rules! opaque {
     ($e: expr) => {
-        $crate::opaque!($e,);
+        $crate::opaque!($e,)
     };
     ($e: expr,) => {
         $crate::parser::combinator::opaque(


### PR DESCRIPTION
The `nightly` toolchain enabled `semicolon_in_expressions_from_macros`, which triggered in `opaque`. We drop the offending semicolon.

Fixes #372