### PR TITLE
parser/combinator: Drop superfluous semicolon in `opaque`

### DIFF
--- a/src/parser/combinator.rs
+++ b/src/parser/combinator.rs
@@ -1434,7 +1434,7 @@ where
 #[macro_export]
 macro_rules! opaque {
     ($e: expr) => {
-        $crate::opaque!($e,);
+        $crate::opaque!($e,)
     };
     ($e: expr,) => {
         $crate::parser::combinator::opaque(


### PR DESCRIPTION
(This change was previously uploaded as #373, approved, but then closed without merging --- presumably as CI was failing and I failed to respond in time? Hence, this commit is a rebase of #373 and [passes CI on my fork](https://github.com/somechris/combine/actions/runs/32586292869/job/97063046628?pr=1))


The `nightly` toolchain enabled `semicolon_in_expressions_from_macros`, which triggered in `opaque`. We drop the offending semicolon.

Fixes #372